### PR TITLE
Fix test run execution live logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
     privileged: true
     build:
       context: ./backend
-    command: /start.sh
+    command: /start-reload.sh
     labels:
       - traefik.enable=true
       - traefik.constraint-label-stack=${TRAEFIK_TAG?Variable not set}


### PR DESCRIPTION
## The issue

The logs were not being shown during the test run executions when running TH in prod mode. The UI would stay stuck loading while the test would run in the background.
<img width="2048" alt="Screenshot 2023-11-21 at 14 53 54" src="https://github.com/project-chip/certification-tool/assets/116589288/b2584220-9dbb-4b1e-9886-155d91f6ec9e">

Running TH in dev mode for backend would not show this issue, the logs were updated as expected.

## What changed

Reverted a change from a recent PR that exchanged the `start-reload` and `start`  `gunicorn` scripts as the command for the backend container creation in the docker-compose file.

## Testing

I tested running in both dev and prod mode and the logs were displayed while the test executed.

<img width="2047" alt="Screenshot 2023-11-21 at 15 02 47" src="https://github.com/project-chip/certification-tool/assets/116589288/35bd296e-0dd7-4a08-9cfc-ecb73595b479">
