### PR TITLE
added "--latest" to build docker image

### DIFF
--- a/scripts/ubuntu/auto-install.sh
+++ b/scripts/ubuntu/auto-install.sh
@@ -36,7 +36,7 @@ echo "*** Build Test Harness Docker containers"
 # Note: `build.sh` shouln't normally be run with sudo
 # but main user was just added to docker, so we still 
 # need root to control docker until machine has been rebooted.
-cd $ROOT_DIR && sudo ./scripts/build.sh
+cd $ROOT_DIR && sudo ./scripts/build.sh --latest
 
 printf "\n\n**********"
 printf "\n*** Fetching sample apps ***\n"


### PR DESCRIPTION
By adding the `--latest` parameter the `.sha_information` file is filled correctly.


Issue: https://github.com/project-chip/certification-tool/issues/98
