### PR TITLE
Update user guide making it clear that VM installation doesn't support Thread

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -156,7 +156,7 @@ Refer to <<bringing-up-of-matter-node-dut-for-certification-testing, Section 5, 
 
 For hobby developers who want to get acquainted with certification tools/process/TC’s, can spin DUT’s using the example apps provided in the SDK. Refer to the instructions to set up one https://groups.csa-iot.org/wg/matter-csg/document/folder/2756[here].
 
-TH runs on Ubuntu 22.04 Server LTS. The official installation method uses a Raspberry Pi (<<th-image-installation-on-raspberry-pi>>), but there's an alternative method used in the tool's development that uses a virtual machine instead (<<th-installation-without-a-raspberry-pi>>). The installation without a Raspeberry Pi doesn't support running Thread.
+TH runs on Ubuntu 22.04 Server LTS. The official installation method uses a Raspberry Pi (<<th-image-installation-on-raspberry-pi>>), but there's an alternative method used in the tool's development that uses a virtual machine instead (<<th-installation-without-a-raspberry-pi>>). Keep in mind that thread networking is not officially supported in VM installations at the moment.
 
 === TH Image Installation on Raspberry Pi
 

--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -68,6 +68,7 @@ endif::[]
 | 12          | 06-Dec-2023  | [Apple]Hilton Lima                  | * Added Custom Yaml test session. +
                                                                      * Updated TH update instructions. +
                                                                      * Revision History table style formated.
+| 13          | 07-Dec-2023  | [Apple]Carolina Lopes               | * Updated instructions on how to install TH without a Raspberry Pi.
 |===
 
 <<<
@@ -155,7 +156,7 @@ Refer to <<bringing-up-of-matter-node-dut-for-certification-testing, Section 5, 
 
 For hobby developers who want to get acquainted with certification tools/process/TC’s, can spin DUT’s using the example apps provided in the SDK. Refer to the instructions to set up one https://groups.csa-iot.org/wg/matter-csg/document/folder/2756[here].
 
-TH runs on Ubuntu 22.04 Server LTS. It can be set up in a Raspberry Pi (<<th-image-installation-on-raspberry-pi>>) or not (<<th-installation-without-a-raspberry-pi>>)
+TH runs on Ubuntu 22.04 Server LTS. The official installation method uses a Raspberry Pi (<<th-image-installation-on-raspberry-pi>>), but there's an alternative method used in the tool's development that uses a virtual machine instead (<<th-installation-without-a-raspberry-pi>>). The installation without a Raspeberry Pi doesn't support running Thread.
 
 === TH Image Installation on Raspberry Pi
 
@@ -263,6 +264,8 @@ The above command might take a while to get executed, wait for 5-10 minutes and 
 |===
 
 === TH installation without a Raspberry Pi
+
+The official installation method uses a Raspberry Pi (<<th-image-installation-on-raspberry-pi>>). **This alternative installation method doesn't support running Thread.**
 
 To install TH without using a Raspberry Pi you'll need a machine with Ubuntu 22.04 Server LTS. You can <<create-an-ubuntu-virtual-machine, create a virtual machine>> for this purpose, but be aware that if the host's architecture is not arm64 you'll need to <<substitute-the-sdks-docker-image-and-update-sample-apps, substitute the SDK's docker image>> in order for it to work properly.
 


### PR DESCRIPTION
Updated the TH User Guide to indicate that installing TH without a Raspberry Pi using a VM doesn't support Thread.