### PR TITLE
Remove build docker images command from autoinstall

### DIFF
--- a/scripts/ubuntu/auto-install.sh
+++ b/scripts/ubuntu/auto-install.sh
@@ -32,12 +32,6 @@ printf "\n*** Getting Test Harness code ***\n"
 
 $SCRIPT_DIR/update.sh
 
-echo "*** Build Test Harness Docker containers"
-# Note: `build.sh` shouln't normally be run with sudo
-# but main user was just added to docker, so we still 
-# need root to control docker until machine has been rebooted.
-cd $ROOT_DIR && sudo ./scripts/build.sh
-
 printf "\n\n**********"
 printf "\n*** Fetching sample apps ***\n"
 $UBUNTU_SCRIPT_DIR/update-sample-apps.sh

--- a/scripts/ubuntu/auto-update.sh
+++ b/scripts/ubuntu/auto-update.sh
@@ -1,4 +1,19 @@
 #! /usr/bin/env bash
+
+ #
+ # Copyright (c) 2023 Project CHIP Authors
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
 ROOT_DIR=$(realpath $(dirname "$0")/../..)
 SCRIPT_DIR="$ROOT_DIR/scripts"
 UBUNTU_SCRIPT_DIR="$SCRIPT_DIR/ubuntu"


### PR DESCRIPTION
For the new installation process, it will no longer be necessary to build container images for the backend and frontend.

This step must only be performed in a development environment and to publish new image versions on the server.