### PR TITLE
Lock docker-py version to 6.1.3

### DIFF
--- a/scripts/ubuntu/1-install-dependendcies.sh
+++ b/scripts/ubuntu/1-install-dependendcies.sh
@@ -57,6 +57,7 @@ packagelist=(
 sudo DEBIAN_FRONTEND=noninteractive sudo apt-get install ${packagelist[@]} -y
 
 # Install Docker Compose, needed for Test Harness
+sudo pip3 install docker==6.1.3
 sudo pip3 install docker-compose
 
 # Install Peotry, needed for Test Harness CLI


### PR DESCRIPTION
`docker-py` has been released in a `7.0.0` that is incompatible with `docker-compose`.

So we need to lock the `docker-py` dependency to version `6.1.3`.