### PR TITLE
Download docker images as part of update.sh

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -49,6 +49,19 @@ cd $ROOT_DIR && \
     git pull && \
     git submodule update --init --recursive
 
+echo "*** Download latest Docker images"
+cd $ROOT_DIR
+# Ensure .env exists
+./scripts/install-default-env.sh
+
+# Download docker images from docker-compose.yml.
+# As this might be run during setup we use `newgrp` command to ensure 
+# docker works.
+newgrp docker << END
+# You can do more lines than just this./
+docker compose pull
+END
+
 echo "*** Update CLI dependencies"
 source ~/.profile #ensure poetry is in path
 cd $ROOT_DIR/cli && poetry install


### PR DESCRIPTION
Docker images used to be downloaded at first `start`, but this can be a bit slow and unexpected.

This PR will explicitly download the required images during an `update`.

Note as the `update` script is also executed during `auto-install`, this will also download the images during first installation.