### PR TITLE
Use built in `docker compose` instead of docker-compose from pip

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -33,7 +33,7 @@ set -e
 BACKEND_COMPOSE="-f docker-compose.override-backend-dev.yml"
 FRONTEND_COMPOSE="-f docker-compose.override-frontend-dev.yml"
 
-# Parse args for which docker-compose overrides to use
+# Parse args for which docker compose overrides to use
 DEV_COMPOSE_FILES=""
 COMPOSE_CACHE_OPTION=""
 BACKEND_DEV=false
@@ -59,7 +59,7 @@ do
 done
 
 # Start docker containers with docker-compose
-docker-compose -f docker-compose.yml $DEV_COMPOSE_FILES up -d
+docker compose -f docker-compose.yml $DEV_COMPOSE_FILES up -d
 
 if [ "$FRONTEND_DEV" = true ] ; then
     echo "!!!! Matter TH frontend started in development mode."

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -18,4 +18,4 @@ ROOT_DIR=$(realpath $(dirname "$0")/..)
 cd $ROOT_DIR
 # Exit in case of error
 set -e
-docker-compose -f docker-compose.yml down
+docker compose -f docker-compose.yml down

--- a/scripts/ubuntu/1-install-dependendcies.sh
+++ b/scripts/ubuntu/1-install-dependendcies.sh
@@ -56,8 +56,5 @@ packagelist=(
 )
 sudo DEBIAN_FRONTEND=noninteractive sudo apt-get install ${packagelist[@]} -y
 
-# Install Docker Compose, needed for Test Harness
-sudo pip3 install docker-compose
-
 # Install Peotry, needed for Test Harness CLI
 curl -sSL https://install.python-poetry.org | python3 -


### PR DESCRIPTION
We've been using Docker Compose V1 since the beginning, but since July '23 Compose V1 is no longer receiving updates.

This PR will update the TH to use Docker Compose V2.

Note, Compose V1 was installed using `pip` and Compose V2 is built into the docker tooling directly, so it's a minor change from using `docker-compose` to `docker compose`

https://docs.docker.com/compose/