### PR TITLE
Silence user prompts about reboot and service restart required

### DIFF
--- a/scripts/pi-setup/install-pi-dependencies.sh
+++ b/scripts/pi-setup/install-pi-dependencies.sh
@@ -14,6 +14,12 @@
  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  # See the License for the specific language governing permissions and
  # limitations under the License.
+
+# Silence user prompts about reboot and service restart required (script will prompt user to reboot in the end)
+sudo sed -i "s/#\$nrconf{kernelhints} = -1;/\$nrconf{kernelhints} = -1;/g" /etc/needrestart/needrestart.conf
+sudo sed -i "s/#\$nrconf{restart} = 'i';/\$nrconf{restart} = 'a';/" /etc/needrestart/needrestart.conf
+
+# Upgrade OS
 sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
 sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 

--- a/scripts/ubuntu/1-install-dependendcies.sh
+++ b/scripts/ubuntu/1-install-dependendcies.sh
@@ -19,6 +19,10 @@
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor --yes -o /usr/share/keyrings/docker-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
+# Silence user prompts about reboot and service restart required (script will prompt user to reboot in the end)
+sudo sed -i "s/#\$nrconf{kernelhints} = -1;/\$nrconf{kernelhints} = -1;/g" /etc/needrestart/needrestart.conf
+sudo sed -i "s/#\$nrconf{restart} = 'i';/\$nrconf{restart} = 'a';/" /etc/needrestart/needrestart.conf
+
 sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
 sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 

--- a/scripts/ubuntu/auto-install.sh
+++ b/scripts/ubuntu/auto-install.sh
@@ -46,6 +46,10 @@ printf "\n\n**********"
 printf "\n*** Fetching PAA Certs from SDK ***\n"
 $UBUNTU_SCRIPT_DIR/update-paa-certs.sh
 
+# Revert needrestart config to default.
+sudo sed -i "s/\$nrconf{kernelhints} = -1;/#\$nrconf{kernelhints} = -1;/g" /etc/needrestart/needrestart.conf
+sudo sed -i "s/\$nrconf{restart} = 'a';/#\$nrconf{restart} = 'i';/" /etc/needrestart/needrestart.conf
+
 printf "\n\n**********"
 printf "\n*** You need to reboot to finish setup. ***\n"
 printf "\n*** Do you want to reboot now? (Press 1 to reboot now)\n"


### PR DESCRIPTION
During our `auto-install.sh` script, the linux kernel will be updated.

This is causing ubuntu to post these warning during installation of later packages:

<img width="624" alt="Screenshot 2024-01-03 at 9 33 17 PM" src="https://github.com/project-chip/certification-tool/assets/698065/58b02996-b43b-4d8d-b07e-280bf6d1d280">
<img width="624" alt="Screenshot 2024-01-03 at 9 33 08 PM" src="https://github.com/project-chip/certification-tool/assets/698065/4145a447-dc7b-46cc-b0c1-7d13096335d7">


This feature is introduced in Ubuntu 22.04 and controlled by `needsreboot`.

In this PR we temporarily modify the `needsreboot` config, to not show these alerts to the user during auto-install.
The default configuration is restored in the end.