### PR TITLE
Updating User Guide's  Link To The TH Release Folder

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -73,6 +73,7 @@ endif::[]
 | 13          | 07-Dec-2023  | [Apple]Carolina Lopes               | * Updated instructions on how to install TH without a Raspberry Pi.
 | 14          | 14-Dec-2023  | [Apple]Hilton Lima                  | * Updated SDK Python Test section.
 | 15          | 20-Dec-2023  | [Apple]Antonio Melo Jr.             | * Updated Test Harness links related to release of Spring 2024.
+| 16          | 04-Jan-2024  | [Apple]Antonio Melo Jr.             | * Updated Test Harness Release location link to the new Drive folder.
 |===
 
 <<<

--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -184,7 +184,7 @@ If the DUT supports thread transport, an RCP dongle provisioned with a recommend
 
 ==== TH Installation on Raspberry Pi
 
-. Go to the https://drive.google.com/file/d/1XOQolEPUhJWYSKty2_FfsmhraTCtGvqP/view?usp=share_link[TH release location] and download the official TH image from the given link on the user’s PC/Mac.
+. Go to the https://drive.google.com/drive/u/1/folders/1ca7CG8QHHYy0g4ScSmiGL3KApNwtZ-w9[TH release location] and download the official TH image from the given link on the user’s PC/Mac.
 . Place the blank SD card into the user’s system USB slot. 
 . Open the https://www.raspberrypi.com/software/[Raspberry Pi Imager] or https://www.balena.io/etcher/[Balena Etcher] tool on the Mac/PC and select the image file from the drop-down list to flash.
 . After the SD card has been flashed with the image, remove the SD card and place it in the Raspberry Pi’s memory card slot.


### PR DESCRIPTION
Updating one link from the user guide pointing to the TH release drive folder.