### PR TITLE
Lock dependencies' versions

### DIFF
--- a/scripts/pi-setup/install-pi-dependencies.sh
+++ b/scripts/pi-setup/install-pi-dependencies.sh
@@ -25,8 +25,8 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 
 # TODO Comment on what dependency is required for:
 packagelist=(
-    linux-modules-extra-raspi
-    pi-bluetooth
+    linux-modules-extra-raspi=5.15.0.1044.42
+    pi-bluetooth=0.1.18ubuntu4
 )
 
 sudo DEBIAN_FRONTEND=noninteractive sudo apt-get install ${packagelist[@]} -y

--- a/scripts/ubuntu/1-install-dependendcies.sh
+++ b/scripts/ubuntu/1-install-dependendcies.sh
@@ -28,35 +28,34 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 
 # TODO Comment on what dependency is required for:
 packagelist=(
-    apt-transport-https
-    avahi-utils                   # Matter uses Avahi
-    ca-certificates
-    curl
-    docker-ce                     # Test Harness uses Docker
-    figlet
-    g++
-    gcc
-    generate-ninja
-    git                           # Update to latest git for code checkout
-    gnupg
-    libavahi-client-dev
-    libcairo2-dev
-    libdbus-1-dev
-    libgirepository1.0-dev
-    libglib2.0-dev
-    libreadline-dev
-    libssl-dev
-    lsb-release
-    net-tools
-    ninja-build
-    npm
-    pkg-config
-    python3-pip                   # Test Harness CLI uses Python              
-    python3-venv                  # Test Harness CLI uses Python
-    software-properties-common
-    toilet
-    unzip
-
+    apt-transport-https=2.4.11
+    avahi-utils=0.8-5ubuntu5.2                  # Matter uses Avahi
+    ca-certificates=20230311ubuntu0.22.04.1
+    curl=7.81.0-1ubuntu1.15
+    docker-ce=5:24.0.7-1~ubuntu.22.04~jammy     # Test Harness uses Docker
+    figlet=2.2.5-3
+    g++=4:11.2.0-1ubuntu1
+    gcc=4:11.2.0-1ubuntu1
+    generate-ninja=0.0~git20220118.0725d78-1
+    git=1:2.34.1-1ubuntu1.10                    # Update to latest git for code checkout
+    gnupg=2.2.27-3ubuntu2.1
+    libavahi-client-dev=0.8-5ubuntu5.2
+    libcairo2-dev=1.16.0-5ubuntu2
+    libdbus-1-dev=1.12.20-2ubuntu4.1
+    libgirepository1.0-dev=1.72.0-1
+    libglib2.0-dev=2.72.4-0ubuntu2.2
+    libreadline-dev=8.1.2-1
+    libssl-dev=3.0.2-0ubuntu1.12
+    lsb-release=11.1.0ubuntu4
+    net-tools=1.60+git20181103.0eebece-1ubuntu5
+    ninja-build=1.10.1-1
+    npm=8.5.1~ds-1
+    pkg-config=0.29.2-1ubuntu3
+    python3-pip=22.0.2+dfsg-1ubuntu0.4          # Test Harness CLI uses Python              
+    python3-venv=3.10.6-1~22.04                 # Test Harness CLI uses Python
+    software-properties-common=0.99.22.9
+    toilet=0.3-1.4
+    unzip=6.0-26ubuntu3.1
 )
 sudo DEBIAN_FRONTEND=noninteractive sudo apt-get install ${packagelist[@]} -y
 


### PR DESCRIPTION
## What changed

- Locked dependencies' versions for packages from `1-install-dependencies.sh` and `install-pi-dependencies.sh`.
- Updated CLI SHA to include `poetry.lock` file.

## Issue

- https://github.com/project-chip/certification-tool/issues/145
