### PR TITLE
Update "TH Installation on Raspberry Pi" section

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -80,6 +80,7 @@ endif::[]
 | 19          | 30-Jan-2024  | [Apple]Romulo Quidute               | * Updated some referenced links.
 | 20          | 07-fev-2024  | [Apple]Hilton Lima                  | * Added 'Common Test Failures' section for SDK tests.
 | 21          | 07-fev-2024  | [Apple]Carolina Lopes               | * Added 'Bringing up the Matter Python REPL' section.
+| 22          | 15-fev-2024  | [Apple]Hilton Lima                  | * Updated 'TH Installation on Raspberry Pi' section.
 |===
 
 <<<
@@ -164,15 +165,15 @@ If the DUT is a controlee (e.g., light bulb), the TH spins a reference commissio
 
 If the DUT is a commissioner/controller, the Test TH spins an example accessory that is shipped with the SDK and uses that for the DUT to provision, control and run certification tests.
 
-Refer to <<bringing-up-of-matter-node-dut-for-certification-testing, Section 5, Bringing Up of Matter Node (DUT) for Certification Testing>> to bring up the DUT and then proceed with device testing by referring to <<test-configuration, Section 8, Test Configuration>>.
+Refer to <<bringing-up-of-matter-node-dut-for-certification-testing, Section 5, Bringing Up of Matter Node (DUT) for Certification Testing>> to bring up the DUT and then proceed with device testing by referring to <<test-configuration, Section 7, Test Configuration>>.
 
 For hobby developers who want to get acquainted with certification tools/process/TC’s, can spin DUT’s using the example apps provided in the SDK. Refer to the instructions to set up one https://groups.csa-iot.org/wg/matter-csg/document/folder/2756[here].
 
 TH runs on Ubuntu 22.04 Server LTS. The official installation method uses a Raspberry Pi (<<th-image-installation-on-raspberry-pi>>), but there's an alternative method used in the tool's development that uses a virtual machine instead (<<th-installation-without-a-raspberry-pi>>). Keep in mind that thread networking is not officially supported in VM installations at the moment.
 
-=== TH Image Installation on Raspberry Pi
+=== TH Installation on Raspberry Pi
 
-There are two ways to obtain the latest TH image on Raspberry Pi. Follow the instructions in <<th-installation-on-raspberry-pi, Section 4.1.2, TH Installation on Raspberry Pi>> to install the image file OR if you already have an image, follow the instructions in <<update-existing-th, Section 4.4, Update Existing TH>> to update the TH image.
+There are two ways to obtain the latest TH on Raspberry Pi. Follow the instructions in <<th-installation-on-raspberry-pi, Section 4.1.2, TH Installation on Raspberry Pi>> to install TH from scratch OR if you already have the TH, follow the instructions in <<update-existing-th, Section 4.4, Update Existing TH>> to update the TH.
 
 ==== *Prerequisites*
 
@@ -180,28 +181,41 @@ The following equipment will be required to have a complete TH setup:
 
 * *Raspberry Pi Version 4 with SD card of minimum 64 GB Memory*
 
-The TH image will be installed on Raspberry PI. The TH image contains couple of docker container(s) with all the required dependencies for certification tests execution.
+The TH will be installed on Raspberry PI. The TH contains couple of docker container(s) with all the required dependencies for certification tests execution.
 
 * *Windows or Linux System (Laptop/Desktop/Mac)*
 
-The Mac/PC will be used to download the TH image and flash on the SD card to be used on Raspberry Pi. Download the https://www.raspberrypi.com/software/[Raspberry Pi Imager] or https://www.balena.io/etcher/[Balena Etcher] tool. The same can be used to set up the required build environment for the Matter SDK or building Matter reference apps for various platforms. 
+The Mac/PC will be used to flash the Ubuntu image on the SD card to be used on Raspberry Pi. Download the https://www.raspberrypi.com/software/[Raspberry Pi Imager] or https://www.balena.io/etcher/[Balena Etcher] tool. The same can be used to set up the required build environment for the Matter SDK or building Matter reference apps for various platforms. 
 
 * *RCP dongle*
 
-If the DUT supports thread transport, an RCP dongle provisioned with a recommended RCP image for the default OTBR router that comes with the TH will be required to function properly. Currently, the OTBR can work with a Nordic RCP dongle or a SiLabs RCP dongle. Refer to <<ot-border-router-otbr-setup, Section 7, OT Border Router (OTBR) Setup>> on how to install an RCP image.
+If the DUT supports thread transport, an RCP dongle provisioned with a recommended RCP firmware for the default OTBR router that comes with the TH will be required to function properly. Currently, the OTBR can work with a Nordic RCP dongle or a SiLabs RCP dongle. Refer to <<ot-border-router-otbr-setup, Section 6, OT Border Router (OTBR) Setup>> on how to install the RCP firmware.
 
 ==== TH Installation on Raspberry Pi
 
-. Go to the https://drive.google.com/drive/u/1/folders/1ca7CG8QHHYy0g4ScSmiGL3KApNwtZ-w9[TH release location] and download the official TH image from the given link on the user’s PC/Mac.
 . Place the blank SD card into the user’s system USB slot. 
-. Open the https://www.raspberrypi.com/software/[Raspberry Pi Imager] or https://www.balena.io/etcher/[Balena Etcher] tool on the Mac/PC and select the image file from the drop-down list to flash.
-. After the SD card has been flashed with the image, remove the SD card and place it in the Raspberry Pi’s memory card slot.
+. Open the https://www.raspberrypi.com/software/[Raspberry Pi Imager] or https://www.balena.io/etcher/[Balena Etcher] tool on the Mac/PC and select the 'Ubuntu Server 22.04 LTS (64-bit)'.
+* Edit the SO custom settings to: 
+** username: ubuntu
+** password: raspberrypi
+** hostname: ubuntu
+* Make sure you have enabled the SSH service.
+. After the SD card has been flashed, remove the SD card and place it in the Raspberry Pi’s memory card slot.
 . Power on the Raspberry Pi and ensure that the local area network, display monitor and keyboard are connected.
-. Enter the default username and password:
-* username: ubuntu
-* password: raspberrypi
+. Enter the username and password.
+. Install the TH system:
+* Clone the TH repository: 
+** `$git clone -b <Target_Branch/Tag> https://github.com/project-chip/certification-tool.git`
+* Goto to TH folder: 
+** `$cd certification-tool`
+* Initialize the submodules: 
+** `$git submodule update --init --recursive`
+* Install/configure the TH dependencies: 
+** `$./scripts/pi-setup/auto-install.sh`
+** At the end of the script, select option 1 to restart the RaspberryPi.
+. Wait about 10 minutes. 
 . Using the _ifconfig_ command, obtain the IP address of the Raspberry Pi. The same IP address will be used to launch the TH user interface on the user's system using the browser.
-. Proceed with test configuration and execution (refer to <<test-configuration, Section 8, Test Configuration>> and <<test-case-execution, Section 9, Test Case Execution>> respectively).
+. Proceed with test configuration and execution (refer to <<test-configuration, Section 7, Test Configuration>> and <<test-case-execution, Section 8, Test Case Execution>> respectively).
 
 
 === Troubleshooting

--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -165,7 +165,7 @@ If the DUT is a controlee (e.g., light bulb), the TH spins a reference commissio
 
 If the DUT is a commissioner/controller, the Test TH spins an example accessory that is shipped with the SDK and uses that for the DUT to provision, control and run certification tests.
 
-Refer to <<bringing-up-of-matter-node-dut-for-certification-testing, Section 5, Bringing Up of Matter Node (DUT) for Certification Testing>> to bring up the DUT and then proceed with device testing by referring to <<test-configuration, Section 7, Test Configuration>>.
+Refer to <<bringing-up-of-matter-node-dut-for-certification-testing, Section 5, Bringing Up of Matter Node (DUT) for Certification Testing>> to bring up the DUT and then proceed with device testing by referring to <<test-configuration, Section 8, Test Configuration>>.
 
 For hobby developers who want to get acquainted with certification tools/process/TC’s, can spin DUT’s using the example apps provided in the SDK. Refer to the instructions to set up one https://groups.csa-iot.org/wg/matter-csg/document/folder/2756[here].
 
@@ -215,7 +215,7 @@ If the DUT supports thread transport, an RCP dongle provisioned with a recommend
 ** At the end of the script, select option 1 to restart the RaspberryPi.
 . Wait about 10 minutes. 
 . Using the _ifconfig_ command, obtain the IP address of the Raspberry Pi. The same IP address will be used to launch the TH user interface on the user's system using the browser.
-. Proceed with test configuration and execution (refer to <<test-configuration, Section 7, Test Configuration>> and <<test-case-execution, Section 8, Test Case Execution>> respectively).
+. Proceed with test configuration and execution (refer to <<test-configuration, Section 8, Test Configuration>> and <<test-case-execution, Section 9, Test Case Execution>> respectively).
 
 
 === Troubleshooting


### PR DESCRIPTION
Removed installation information using an image

https://github.com/project-chip/certification-tool/blob/update_th_instalation_steps/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc