### PR TITLE
Fix installation error: Remove libssl-dev version

### DIFF
--- a/scripts/pi-setup/install-pi-dependencies.sh
+++ b/scripts/pi-setup/install-pi-dependencies.sh
@@ -26,8 +26,14 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 
 # TODO Comment on what dependency is required for:
 packagelist=(
-    linux-modules-extra-raspi=5.15.0.1046.44
-    pi-bluetooth=0.1.18ubuntu4
+    "linux-modules-extra-raspi (>=5.15.0.1046.44)"
+    "pi-bluetooth (=0.1.18ubuntu4)"
 )
 
-sudo DEBIAN_FRONTEND=noninteractive sudo apt-get install ${packagelist[@]} -y
+SAVEIFS=$IFS
+IFS=$(echo -en "\r")
+for package in ${packagelist[@]}; do
+  echo "# Instaling package: ${package[@]}"
+  sudo DEBIAN_FRONTEND=noninteractive sudo apt satisfy ${package[@]} -y --allow-downgrades
+done
+IFS=$SAVEIFS 

--- a/scripts/ubuntu/1-install-dependendcies.sh
+++ b/scripts/ubuntu/1-install-dependendcies.sh
@@ -32,7 +32,7 @@ packagelist=(
     "apt-transport-https (=2.4.11)"
     "avahi-utils (>=0.8-5ubuntu5.2)"                 # Matter uses Avahi
     "ca-certificates (=20230311ubuntu0.22.04.1)"
-    "docker-ce (=5:24.0.7-1~ubuntu.22.04~jammy)"     # Test Harness uses Docker
+    "docker-ce (>=5:24.0.7-1~ubuntu.22.04~jammy)"    # Test Harness uses Docker
     "figlet (=2.2.5-3)"
     "g++ (=4:11.2.0-1ubuntu1)"
     "gcc (=4:11.2.0-1ubuntu1)"
@@ -52,13 +52,13 @@ packagelist=(
     "python3-venv (=3.10.6-1~22.04)"                 # Test Harness CLI uses Python
     "software-properties-common (=0.99.22.9)"
     "toilet (=0.3-1.4)"
-    "unzip (=6.0-26ubuntu3.1)"
+    "unzip (>=6.0-26ubuntu3.1)"
 )
 
 SAVEIFS=$IFS
 IFS=$(echo -en "\r")
 for package in ${packagelist[@]}; do
-  sudo DEBIAN_FRONTEND=noninteractive sudo apt satisfy ${package[@]} -y
+  sudo DEBIAN_FRONTEND=noninteractive sudo apt satisfy ${package[@]} -y --allow-downgrades
 done
 IFS=$SAVEIFS 
 

--- a/scripts/ubuntu/1-install-dependendcies.sh
+++ b/scripts/ubuntu/1-install-dependendcies.sh
@@ -62,7 +62,5 @@ for package in ${packagelist[@]}; do
 done
 IFS=$SAVEIFS 
 
-# sudo DEBIAN_FRONTEND=noninteractive sudo apt-get install ${packagelist[@]} -y --allow-downgrades
-
 # Install Peotry, needed for Test Harness CLI
 curl -sSL https://install.python-poetry.org | python3 -

--- a/scripts/ubuntu/1-install-dependendcies.sh
+++ b/scripts/ubuntu/1-install-dependendcies.sh
@@ -65,4 +65,4 @@ IFS=$SAVEIFS
 # sudo DEBIAN_FRONTEND=noninteractive sudo apt-get install ${packagelist[@]} -y --allow-downgrades
 
 # Install Peotry, needed for Test Harness CLI
-# curl -sSL https://install.python-poetry.org | python3 -
+curl -sSL https://install.python-poetry.org | python3 -

--- a/scripts/ubuntu/1-install-dependendcies.sh
+++ b/scripts/ubuntu/1-install-dependendcies.sh
@@ -43,7 +43,7 @@ packagelist=(
     libgirepository1.0-dev=1.72.0-1
     libglib2.0-dev=2.72.4-0ubuntu2.2
     libreadline-dev=8.1.2-1
-    libssl-dev
+    libssl-dev                                  # Apparently with each update, previous versions of the library are removed
     net-tools=1.60+git20181103.0eebece-1ubuntu5
     ninja-build=1.10.1-1
     npm=8.5.1~ds-1

--- a/scripts/ubuntu/1-install-dependendcies.sh
+++ b/scripts/ubuntu/1-install-dependendcies.sh
@@ -29,32 +29,40 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 
 # TODO Comment on what dependency is required for:
 packagelist=(
-    apt-transport-https=2.4.11
-    avahi-utils=0.8-5ubuntu5.2                  # Matter uses Avahi
-    ca-certificates=20230311ubuntu0.22.04.1
-    docker-ce=5:24.0.7-1~ubuntu.22.04~jammy     # Test Harness uses Docker
-    figlet=2.2.5-3
-    g++=4:11.2.0-1ubuntu1
-    gcc=4:11.2.0-1ubuntu1
-    generate-ninja=0.0~git20220118.0725d78-1
-    libavahi-client-dev=0.8-5ubuntu5.2
-    libcairo2-dev=1.16.0-5ubuntu2
-    libdbus-1-dev=1.12.20-2ubuntu4.1
-    libgirepository1.0-dev=1.72.0-1
-    libglib2.0-dev=2.72.4-0ubuntu2.2
-    libreadline-dev=8.1.2-1
-    libssl-dev                                  # Apparently with each update, previous versions of the library are removed
-    net-tools=1.60+git20181103.0eebece-1ubuntu5
-    ninja-build=1.10.1-1
-    npm=8.5.1~ds-1
-    pkg-config=0.29.2-1ubuntu3
-    python3-pip=22.0.2+dfsg-1ubuntu0.4          # Test Harness CLI uses Python              
-    python3-venv=3.10.6-1~22.04                 # Test Harness CLI uses Python
-    software-properties-common=0.99.22.9
-    toilet=0.3-1.4
-    unzip=6.0-26ubuntu3.1
+    "apt-transport-https (=2.4.11)"
+    "avahi-utils (>=0.8-5ubuntu5.2)"                 # Matter uses Avahi
+    "ca-certificates (=20230311ubuntu0.22.04.1)"
+    "docker-ce (=5:24.0.7-1~ubuntu.22.04~jammy)"     # Test Harness uses Docker
+    "figlet (=2.2.5-3)"
+    "g++ (=4:11.2.0-1ubuntu1)"
+    "gcc (=4:11.2.0-1ubuntu1)"
+    "generate-ninja (=0.0~git20220118.0725d78-1)"
+    "libavahi-client-dev (=0.8-5ubuntu5.2)"
+    "libcairo2-dev (=1.16.0-5ubuntu2)"
+    "libdbus-1-dev (=1.12.20-2ubuntu4.1)"
+    "libgirepository1.0-dev (=1.72.0-1)"
+    "libglib2.0-dev (=2.72.4-0ubuntu2.2)"
+    "libreadline-dev (=8.1.2-1)"
+    "libssl-dev (>=3.0.2-0ubuntu1.14)"               # Apparently with each update, previous versions of the library are removed
+    "net-tools (=1.60+git20181103.0eebece-1ubuntu5)"
+    "ninja-build (=1.10.1-1)"
+    "npm (=8.5.1~ds-1)"
+    "pkg-config (=0.29.2-1ubuntu3)"
+    "python3-pip (=22.0.2+dfsg-1ubuntu0.4)"          # Test Harness CLI uses Python              
+    "python3-venv (=3.10.6-1~22.04)"                 # Test Harness CLI uses Python
+    "software-properties-common (=0.99.22.9)"
+    "toilet (=0.3-1.4)"
+    "unzip (=6.0-26ubuntu3.1)"
 )
-sudo DEBIAN_FRONTEND=noninteractive sudo apt-get install ${packagelist[@]} -y --allow-downgrades
+
+SAVEIFS=$IFS
+IFS=$(echo -en "\r")
+for package in ${packagelist[@]}; do
+  sudo DEBIAN_FRONTEND=noninteractive sudo apt satisfy ${package[@]} -y
+done
+IFS=$SAVEIFS 
+
+# sudo DEBIAN_FRONTEND=noninteractive sudo apt-get install ${packagelist[@]} -y --allow-downgrades
 
 # Install Peotry, needed for Test Harness CLI
-curl -sSL https://install.python-poetry.org | python3 -
+# curl -sSL https://install.python-poetry.org | python3 -

--- a/scripts/ubuntu/1-install-dependendcies.sh
+++ b/scripts/ubuntu/1-install-dependendcies.sh
@@ -58,6 +58,7 @@ packagelist=(
 SAVEIFS=$IFS
 IFS=$(echo -en "\r")
 for package in ${packagelist[@]}; do
+  echo "# Instaling package: ${package[@]}"
   sudo DEBIAN_FRONTEND=noninteractive sudo apt satisfy ${package[@]} -y --allow-downgrades
 done
 IFS=$SAVEIFS 

--- a/scripts/ubuntu/1-install-dependendcies.sh
+++ b/scripts/ubuntu/1-install-dependendcies.sh
@@ -43,7 +43,7 @@ packagelist=(
     libgirepository1.0-dev=1.72.0-1
     libglib2.0-dev=2.72.4-0ubuntu2.2
     libreadline-dev=8.1.2-1
-    libssl-dev=3.0.2-0ubuntu1.14
+    libssl-dev
     net-tools=1.60+git20181103.0eebece-1ubuntu5
     ninja-build=1.10.1-1
     npm=8.5.1~ds-1


### PR DESCRIPTION
Apparently with each update, previous versions of the library are removed

Tested on Ubuntu Server 22.04.4:

![image](https://github.com/project-chip/certification-tool/assets/116589806/94e173a0-3410-4338-b2b7-8651c6d10514)
