### PR TITLE
#2 Move TH tests from backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /usr/bin/docker:/usr/bin/docker
       - /var/run/dbus:/var/run/dbus
-      - ./backend/test_collections:/app/test_collections # mount test_collections in container
+      - ./test_collections:/app/test_collections # mount test_collections in container
     depends_on:
       - db
     env_file:

--- a/test_collections/.disabled_test_collections
+++ b/test_collections/.disabled_test_collections
@@ -1,0 +1,3 @@
+tool_unit_tests
+tool_blocklist_unit_tests
+__pytest_cache__

--- a/test_collections/sample_tests/__init__.py
+++ b/test_collections/sample_tests/__init__.py
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pathlib import Path
+
+from app.test_engine.test_collection_discovery import test_collection_declaration
+
+COLLECTION_PATH = Path(__file__).parent
+
+sample_tests_collection = test_collection_declaration(COLLECTION_PATH, "sample_tests")

--- a/test_collections/sample_tests/sample_suite_1/__init__.py
+++ b/test_collections/sample_tests/sample_suite_1/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .sample_suite_1 import SampleTestSuite1

--- a/test_collections/sample_tests/sample_suite_1/sample_suite_1.py
+++ b/test_collections/sample_tests/sample_suite_1/sample_suite_1.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestSuite
+
+
+class SampleTestSuite1(TestSuite):
+    metadata = {
+        "public_id": "SampleTestSuite1",
+        "version": "1.2.3",
+        "title": "This is Test Suite 1",
+        "description": "This is Test Suite 1, it will not get a very long description",
+    }
+
+    async def setup(self) -> None:
+        logger.info("This is a test setup")
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test cleanup")

--- a/test_collections/sample_tests/sample_suite_1/tcss1001/__init__.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1001/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss1001 import TCSS1001

--- a/test_collections/sample_tests/sample_suite_1/tcss1001/tcss1001.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1001/tcss1001.py
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from asyncio import sleep
+
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS1001(TestCase):
+    metadata = {
+        "public_id": "TCSS1001",
+        "version": "1.2.3",
+        "title": "This is Test Case tcss1001",
+        "description": """This is Test Case tcss1001,\
+        it will not get a very long description""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+            TestStep("Test Step 4"),
+            TestStep("Test Step 5"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 5):
+            logger.info("Executing something in Step {}".format(i))
+            # Test some async operation
+            await sleep(1)
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/sample_suite_1/tcss1002/__init__.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1002/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss1002 import TCSS1002

--- a/test_collections/sample_tests/sample_suite_1/tcss1002/tcss1002.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1002/tcss1002.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS1002(TestCase):
+    metadata = {
+        "public_id": "TCSS1002",
+        "version": "3.2.1",
+        "title": "This is Test Case tcss1002",
+        "description": "This is Test Case tcss1002, it will not get a very long\
+         description",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+            TestStep("Test Step 4"),
+            TestStep("Test Step 5"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 5):
+            logger.info("Executing something in Step {}".format(i))
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/sample_suite_1/tcss1003/__init__.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1003/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss1003 import TCSS1003

--- a/test_collections/sample_tests/sample_suite_1/tcss1003/tcss1003.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1003/tcss1003.py
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS1003(TestCase):
+    metadata = {
+        "public_id": "TCSS1003",
+        "version": "4.5.6",
+        "title": "This is Test Case tcss1003",
+        "description": """This is Test Case tcss1003,\
+        it will not get a very long description""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 3):
+            logger.info("Executing something in Step {}".format(i))
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/sample_suite_1/tcss1004/__init__.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1004/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss1004 import TCSS1004

--- a/test_collections/sample_tests/sample_suite_1/tcss1004/tcss1004.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1004/tcss1004.py
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS1004(TestCase):
+    metadata = {
+        "public_id": "TCSS1004",
+        "version": "1.0",
+        "title": "This is Test Case tcss1004",
+        "description": """This is Test Case tcss1004,\
+        it will not get a very long description""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+            TestStep("Test Step 4"),
+            TestStep("Test Step 5"),
+            TestStep("Test Step 6"),
+            TestStep("Test Step 7"),
+            TestStep("Test Step 8"),
+            TestStep("Test Step 9"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 9):
+            logger.info("Executing something in Step {}".format(i))
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/sample_suite_1/tcss1005/__init__.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1005/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss1005 import TCSS1005

--- a/test_collections/sample_tests/sample_suite_1/tcss1005/tcss1005.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1005/tcss1005.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS1005(TestCase):
+    metadata = {
+        "public_id": "TCSS1005",
+        "version": "1.0",
+        "title": "This is Test Case tcss1005",
+        "description": """This is Test Case tcss1005,\
+        it will not get a very long description""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+            TestStep("Test Step 4"),
+            TestStep("Test Step 5"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 5):
+            logger.info("Executing something in Step {}".format(i))
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/sample_suite_1/tcss1006/__init__.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1006/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss1006 import TCSS1006

--- a/test_collections/sample_tests/sample_suite_1/tcss1006/tcss1006.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1006/tcss1006.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS1006(TestCase):
+    metadata = {
+        "public_id": "TCSS1006",
+        "version": "1.2.3",
+        "title": "This is Test Case tcss1006",
+        "description": """This is Test Case tcss1006,\
+        it will not get a very long description""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+            TestStep("Test Step 4"),
+            TestStep("Test Step 5"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 5):
+            logger.info("Executing something in Step {}".format(i))
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/sample_suite_1/tcss1007/__init__.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1007/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss1007 import TCSS1007

--- a/test_collections/sample_tests/sample_suite_1/tcss1007/tcss1007.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1007/tcss1007.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS1007(TestCase):
+    metadata = {
+        "public_id": "TCSS1007",
+        "version": "1.2.3",
+        "title": "This is Test Case tcss1007",
+        "description": """This is Test Case tcss1007,\
+        it will not get a very long description""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+            TestStep("Test Step 4"),
+            TestStep("Test Step 5"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 5):
+            logger.info("Executing something in Step {}".format(i))
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/sample_suite_1/tcss1008/__init__.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1008/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss1008 import TCSS1008

--- a/test_collections/sample_tests/sample_suite_1/tcss1008/tcss1008.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1008/tcss1008.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS1008(TestCase):
+    metadata = {
+        "public_id": "TCSS1008",
+        "version": "1.2.3",
+        "title": "This is Test Case tcss1008",
+        "description": """This is Test Case tcss1008,\
+        it will not get a very long description""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+            TestStep("Test Step 4"),
+            TestStep("Test Step 5"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 5):
+            logger.info("Executing something in Step {}".format(i))
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/sample_suite_1/tcss1009/__init__.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1009/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss1009 import TCSS1009

--- a/test_collections/sample_tests/sample_suite_1/tcss1009/tcss1009.py
+++ b/test_collections/sample_tests/sample_suite_1/tcss1009/tcss1009.py
@@ -1,0 +1,112 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import random
+from enum import IntEnum
+from typing import Optional
+
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+from app.user_prompt_support import (
+    OptionsSelectPromptRequest,
+    PromptResponse,
+    UserPromptSupport,
+    UserResponseStatusEnum,
+)
+
+
+class TestError(Exception):
+    pass
+
+
+class PromptOptions(IntEnum):
+    YES_FAIL = 1
+    NO_PASS = 2
+    RANDOM = 3
+
+
+class TCSS1009(TestCase, UserPromptSupport):
+    metadata = {
+        "public_id": "TCSS1009",
+        "version": "1.2.3",
+        "title": "User prompt sample test",
+        "description": """This is Test Case tcss1009,\
+        it will not get a very long description""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Always pass"),
+            TestStep("Prompt user"),
+            TestStep("Evaluate user response"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        # Step 1:
+        self.next_step()
+
+        # Step 2:
+        prompt_response = await self.__prompt_user()
+        self.next_step()
+
+        # Step 3:
+        self.__evaluate_user_response(prompt_response)
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")
+
+    async def __prompt_user(self) -> Optional[PromptResponse]:
+        prompt = "Do you want this test to fail?"
+        options = {
+            "Yes, please": PromptOptions.YES_FAIL,
+            "No, please pass it": PromptOptions.NO_PASS,
+            "Make it random": PromptOptions.RANDOM,
+        }
+        prompt_request = OptionsSelectPromptRequest(
+            prompt=prompt, options=options, timeout=30
+        )
+        return await self.send_prompt_request(prompt_request)
+
+    def __evaluate_user_response(
+        self, prompt_response: Optional[PromptResponse]
+    ) -> None:
+        if prompt_response is None:
+            raise TestError("User response returned Null")
+
+        if prompt_response.status_code == UserResponseStatusEnum.TIMEOUT:
+            raise TestError("User prompt timed out")
+
+        if prompt_response.status_code == UserResponseStatusEnum.CANCELLED:
+            self.mark_step_failure("User cancelled the prompt")
+            return
+
+        if prompt_response.status_code == UserResponseStatusEnum.INVALID:
+            self.mark_step_failure("User prompt response is invalid")
+            return
+
+        if prompt_response.response == PromptOptions.YES_FAIL:
+            self.mark_step_failure("User wanted test to fail")
+            return
+
+        if prompt_response.response == PromptOptions.NO_PASS:
+            return
+
+        if prompt_response.response == PromptOptions.RANDOM:
+            # Answer: Make it random
+            if bool(random.getrandbits(1)):
+                self.mark_step_failure("Test randomly failed")

--- a/test_collections/sample_tests/sample_suite_2/__init__.py
+++ b/test_collections/sample_tests/sample_suite_2/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .sample_suite_2 import SampleTestSuite2

--- a/test_collections/sample_tests/sample_suite_2/sample_suite_2.py
+++ b/test_collections/sample_tests/sample_suite_2/sample_suite_2.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestSuite
+
+
+class SampleTestSuite2(TestSuite):
+    metadata = {
+        "public_id": "SampleTestSuite2",
+        "version": "4.5.6",
+        "title": "This is Test Suite 2 with version 4.5.6",
+        "description": "This is Test Suite 2, it will not get a very long description",
+    }
+
+    async def setup(self) -> None:
+        logger.info("This is a test setup")
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test cleanup")

--- a/test_collections/sample_tests/sample_suite_2/tcss2001/__init__.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2001/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss2001 import TCSS2001

--- a/test_collections/sample_tests/sample_suite_2/tcss2001/tcss2001.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2001/tcss2001.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS2001(TestCase):
+    metadata = {
+        "public_id": "TCSS2001",
+        "version": "1.2.3",
+        "title": "This is Test Case tcss2001",
+        "description": """This is Test Case tcss2001,\
+        it will not get a very long description""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+            TestStep("Test Step 4"),
+            TestStep("Test Step 5"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 5):
+            logger.info("Executing something in Step {}".format(i))
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/sample_suite_2/tcss2002/__init__.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2002/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss2002 import TCSS2002

--- a/test_collections/sample_tests/sample_suite_2/tcss2002/tcss2002.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2002/tcss2002.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS2002(TestCase):
+    metadata = {
+        "public_id": "TCSS2002",
+        "version": "3.2.1",
+        "title": "This is Test Case tcss2002",
+        "description": "This is Test Case tcss2002, it will not get a very long\
+         description",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+            TestStep("Test Step 4"),
+            TestStep("Test Step 5"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 5):
+            logger.info("Executing something in Step {}".format(i))
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/sample_suite_2/tcss2003/__init__.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2003/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss2003 import TCSS2003

--- a/test_collections/sample_tests/sample_suite_2/tcss2003/tcss2003.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2003/tcss2003.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS2003(TestCase):
+    metadata = {
+        "public_id": "TCSS2003",
+        "version": "1.2.3",
+        "title": "This is Test Case tcss2003",
+        "description": """This is Test Case tcss2003,\
+        it will not get a very long description""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+            TestStep("Test Step 4"),
+            TestStep("Test Step 5"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 5):
+            logger.info("Executing something in Step {}".format(i))
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/sample_suite_2/tcss2004/__init__.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2004/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss2004 import TCSS2004

--- a/test_collections/sample_tests/sample_suite_2/tcss2004/tcss2004.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2004/tcss2004.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS2004(TestCase):
+    metadata = {
+        "public_id": "TCSS2004",
+        "version": "1.2.3",
+        "title": "This is Test Case tcss2004",
+        "description": """This is Test Case tcss2004,\
+        it will not get a very long description""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+            TestStep("Test Step 4"),
+            TestStep("Test Step 5"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 5):
+            logger.info("Executing something in Step {}".format(i))
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/sample_suite_2/tcss2005/__init__.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2005/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss2005 import TCSS2005

--- a/test_collections/sample_tests/sample_suite_2/tcss2005/tcss2005.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2005/tcss2005.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS2005(TestCase):
+    metadata = {
+        "public_id": "TCSS2005",
+        "version": "1.2.3",
+        "title": "This is Test Case tcss2005",
+        "description": """This is Test Case tcss2005,\
+        it will not get a very long description""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+            TestStep("Test Step 4"),
+            TestStep("Test Step 5"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 5):
+            logger.info("Executing something in Step {}".format(i))
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/sample_suite_2/tcss2006/__init__.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2006/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss2006 import TCSS2006

--- a/test_collections/sample_tests/sample_suite_2/tcss2006/tcss2006.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2006/tcss2006.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS2006(TestCase):
+    metadata = {
+        "public_id": "TCSS2006",
+        "version": "1.2.3",
+        "title": "This is Test Case tcss2006",
+        "description": """This is Test Case tcss2006,\
+        it will not get a very long description""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+            TestStep("Test Step 4"),
+            TestStep("Test Step 5"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 5):
+            logger.info("Executing something in Step {}".format(i))
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/sample_suite_2/tcss2007/__init__.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2007/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss2007 import TCSS2007

--- a/test_collections/sample_tests/sample_suite_2/tcss2007/tcss2007.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2007/tcss2007.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS2007(TestCase):
+    metadata = {
+        "public_id": "TCSS2007",
+        "version": "1.2.3",
+        "title": "This is Test Case tcss2007",
+        "description": """This is Test Case tcss2007,\
+        it will not get a very long description""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+            TestStep("Test Step 4"),
+            TestStep("Test Step 5"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 5):
+            logger.info("Executing something in Step {}".format(i))
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/sample_suite_2/tcss2008/__init__.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2008/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss2008 import TCSS2008

--- a/test_collections/sample_tests/sample_suite_2/tcss2008/tcss2008.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2008/tcss2008.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS2008(TestCase):
+    metadata = {
+        "public_id": "TCSS2008",
+        "version": "1.2.3",
+        "title": "This is Test Case tcss2008",
+        "description": """This is Test Case tcss2008,\
+        it will not get a very long description""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+            TestStep("Test Step 4"),
+            TestStep("Test Step 5"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 5):
+            logger.info("Executing something in Step {}".format(i))
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/sample_suite_2/tcss2009/__init__.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2009/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tcss2009 import TCSS2009

--- a/test_collections/sample_tests/sample_suite_2/tcss2009/tcss2009.py
+++ b/test_collections/sample_tests/sample_suite_2/tcss2009/tcss2009.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCSS2009(TestCase):
+    metadata = {
+        "public_id": "TCSS2009",
+        "version": "1.2.3",
+        "title": "This is Test Case tcss2009",
+        "description": """This is Test Case tcss2009,\
+        it will not get a very long description""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+            TestStep("Test Step 4"),
+            TestStep("Test Step 5"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for i in range(1, 5):
+            logger.info("Executing something in Step {}".format(i))
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/sample_tests/setup.sh
+++ b/test_collections/sample_tests/setup.sh
@@ -1,0 +1,21 @@
+#! /usr/bin/env bash
+
+ #
+ # Copyright (c) 2024 Project CHIP Authors
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ # http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+set -e
+
+printf "\n*** Running Sample Tests Setup ***\n"
+
+# Add program specific dependencies here

--- a/test_collections/tool_blocklist_unit_tests/__init__.py
+++ b/test_collections/tool_blocklist_unit_tests/__init__.py
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pathlib import Path
+
+from app.test_engine.test_collection_discovery import test_collection_declaration
+
+COLLECTION_PATH = Path(__file__).parent
+
+tool_blocklist_unit_tests_collection = test_collection_declaration(
+    COLLECTION_PATH, "tool_blocklist_unit_tests"
+)

--- a/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_1/__init__.py
+++ b/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_1/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .suite import TestSuiteBlocklist1

--- a/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_1/suite.py
+++ b/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_1/suite.py
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.models import TestSuite
+
+
+class TestSuiteBlocklist1(TestSuite):
+    metadata = {
+        "public_id": "TestSuiteBlocklist1",
+        "version": "0.0.1",
+        "title": "Test Suite TestSuiteBlocklist1",
+        "description": "",
+    }

--- a/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_1/testcases/__init__.py
+++ b/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_1/testcases/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tc_blocklist_1_1 import TCBlocklist11

--- a/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_1/testcases/tc_blocklist_1_1.py
+++ b/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_1/testcases/tc_blocklist_1_1.py
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCBlocklist11(TestCase):
+    metadata = {
+        "public_id": "TC_Blocklist_1_1",
+        "version": "1.2.3",
+        "title": "TC-Blocklist-1.1",
+        "description": """This Test Case is built to test the test case blocklist,\
+             it is supposed pass instantly""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [TestStep("Test Step 1")]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        pass
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_2/__init__.py
+++ b/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_2/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .suite import TestSuiteBlocklist2

--- a/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_2/suite.py
+++ b/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_2/suite.py
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.models import TestSuite
+
+
+class TestSuiteBlocklist2(TestSuite):
+    metadata = {
+        "public_id": "TestSuiteBlocklist2",
+        "version": "0.0.1",
+        "title": "Test Suite TestSuiteBlocklist2",
+        "description": "",
+    }

--- a/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_2/testcases/__init__.py
+++ b/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_2/testcases/__init__.py
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tc_blocklist_2_1 import TCBlocklist21
+from .tc_blocklist_2_2 import TCBlocklist22

--- a/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_2/testcases/tc_blocklist_2_1.py
+++ b/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_2/testcases/tc_blocklist_2_1.py
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCBlocklist21(TestCase):
+    metadata = {
+        "public_id": "TC_Blocklist_2_1",
+        "version": "1.2.3",
+        "title": "TC-Blocklist-2.1",
+        "description": """This Test Case is built to test the test case blocklist,\
+             it is supposed pass instantly""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [TestStep("Test Step 1")]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        pass
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_2/testcases/tc_blocklist_2_2.py
+++ b/test_collections/tool_blocklist_unit_tests/test_suite_blocklist_2/testcases/tc_blocklist_2_2.py
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCBlocklist22(TestCase):
+    metadata = {
+        "public_id": "TC_Blocklist_2_2",
+        "version": "1.2.3",
+        "title": "TC-Blocklist-2.2",
+        "description": """This Test Case is built to test the test case blocklist,\
+             it is supposed pass instantly""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [TestStep("Test Step 1")]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        pass
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/tool_unit_tests/__init__.py
+++ b/test_collections/tool_unit_tests/__init__.py
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pathlib import Path
+
+from app.test_engine.test_collection_discovery import test_collection_declaration
+
+COLLECTION_PATH = Path(__file__).parent
+
+tool_unit_tests_collection = test_collection_declaration(
+    COLLECTION_PATH, "tool_unit_tests"
+)

--- a/test_collections/tool_unit_tests/test_suite_async/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_async/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .test_runner_test_suite_async import TestSuiteAsync

--- a/test_collections/tool_unit_tests/test_suite_async/tctr_instant_pass/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_async/tctr_instant_pass/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tctr_instant_pass import TCTRInstantPass

--- a/test_collections/tool_unit_tests/test_suite_async/tctr_instant_pass/tctr_instant_pass.py
+++ b/test_collections/tool_unit_tests/test_suite_async/tctr_instant_pass/tctr_instant_pass.py
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCTRInstantPass(TestCase):
+    metadata = {
+        "public_id": "TCTRInstantPass",
+        "version": "1.2.3",
+        "title": "This is Test Case tctr_instant_pass",
+        "description": """This Test Case is built to test the test runner,\
+             it is supposed pass instantly""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [TestStep("Test Step 1")]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        pass
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/tool_unit_tests/test_suite_async/tctr_never_ending/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_async/tctr_never_ending/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tctr_never_ending import TCTRNeverEnding

--- a/test_collections/tool_unit_tests/test_suite_async/tctr_never_ending/tctr_never_ending.py
+++ b/test_collections/tool_unit_tests/test_suite_async/tctr_never_ending/tctr_never_ending.py
@@ -1,0 +1,53 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from asyncio import sleep
+
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCTRNeverEnding(TestCase):
+    metadata = {
+        "public_id": "TCTRNeverEnding",
+        "version": "1.2.3",
+        "title": "This is Test Case tctr_never_ending",
+        "description": """This Test Case is built to test the test runner,\
+             step 2 is supposed to run for ever""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("No-op"),
+            TestStep("Run forever"),
+            TestStep("Not reachable"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        logger.info("This is a test step 1: No-op")
+        self.next_step()
+        logger.info("This is a test step 2: sleep for ever")
+        while True:
+            await sleep(1)
+
+        # We know this is unreachable, but it still makes sense for unit testing
+        self.next_step()  # type: ignore
+        logger.info("This is a test step 3: we will never get here")
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/tool_unit_tests/test_suite_async/tctr_user_prompt/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_async/tctr_user_prompt/__init__.py
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tctr_options_select_user_prompt import TCTROptionsSelectUserPrompt
+from .tctr_text_input_user_prompt import TCTRTextInputUserPrompt
+from .tctr_upload_file_user_prompt import TCTRUploadFileUserPrompt

--- a/test_collections/tool_unit_tests/test_suite_async/tctr_user_prompt/tctr_options_select_user_prompt.py
+++ b/test_collections/tool_unit_tests/test_suite_async/tctr_user_prompt/tctr_options_select_user_prompt.py
@@ -1,0 +1,77 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+from app.user_prompt_support import (
+    OptionsSelectPromptRequest,
+    PromptRequest,
+    UserPromptSupport,
+    UserResponseStatusEnum,
+)
+
+
+class TestError(Exception):
+    pass
+
+
+class TCTROptionsSelectUserPrompt(TestCase, UserPromptSupport):
+    metadata = {
+        "public_id": "TCTROptionsSelectUserPrompt",
+        "version": "1.2.3",
+        "title": "This is Test Case tctr_options_select_user_prompt",
+        "description": """This Test Case is built to test the test runner,\
+             step 2 is supposed to run for ever""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("No-op"),
+            TestStep("Prompt User"),
+            TestStep("Pass on option 1"),
+        ]
+
+    def _create_custom_prompt_request(self) -> PromptRequest:
+        prompt = "Please select one of the following options"
+        options = {"Options 1": 1, "Options 2": 2, "Options 3": 3, "Options 4": 4}
+        prompt_request = OptionsSelectPromptRequest(
+            prompt=prompt, options=options, timeout=2
+        )
+        return prompt_request
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        logger.info("This is a test step 1: No-op")
+        self.next_step()
+
+        logger.info("This is a test step 2: Prompting the user")
+
+        prompt_request = self._create_custom_prompt_request()
+        prompt_response = await self.send_prompt_request(prompt_request=prompt_request)
+        if prompt_response is None:
+            raise TestError("User response returned Null")
+
+        logger.info("This is a test step 3: Got the response " + str(prompt_response))
+        if (
+            prompt_response.status_code != UserResponseStatusEnum.OKAY
+            or prompt_response.response != 1
+        ):
+            raise TestError("Failed test step 3: Expected Option 1")
+        self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/tool_unit_tests/test_suite_async/tctr_user_prompt/tctr_text_input_user_prompt.py
+++ b/test_collections/tool_unit_tests/test_suite_async/tctr_user_prompt/tctr_text_input_user_prompt.py
@@ -1,0 +1,84 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+from app.user_prompt_support import (
+    PromptRequest,
+    TextInputPromptRequest,
+    UserPromptSupport,
+    UserResponseStatusEnum,
+)
+
+
+class PromptResponseError(Exception):
+    pass
+
+
+class TCTRTextInputUserPrompt(TestCase, UserPromptSupport):
+    metadata = {
+        "public_id": "TCTRTextInputUserPrompt",
+        "version": "1.2.3",
+        "title": "This is Test Case tctr_text_input_user_prompt",
+        "description": """This Test Case is built to test the test runner,\
+             step 2 is supposed to run for ever""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("No-op"),
+            TestStep("Prompt User"),
+            TestStep("Pass on option 1"),
+        ]
+
+    def _create_custom_prompt_request(self) -> PromptRequest:
+        text_input_param = {
+            "prompt": "Please type email info in the text box",
+            "placeholder_text": "some@email.com",
+            "default_value": "some@email.com",
+            "regex_pattern": "^\\S+@\\S+\\.\\S+$",
+        }
+        prompt_request = TextInputPromptRequest(
+            **text_input_param,
+            timeout=2,
+        )
+        return prompt_request
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        logger.info("This is a test step 1: No-op")
+        self.next_step()
+
+        logger.info("This is a test step 2: Prompting the user")
+
+        prompt_request = self._create_custom_prompt_request()
+        prompt_response = await self.send_prompt_request(prompt_request=prompt_request)
+        if prompt_response is None:
+            raise PromptResponseError("User response returned Null")
+
+        logger.info("This is a test step 3: Got the response " + str(prompt_response))
+        if (
+            prompt_response.status_code != UserResponseStatusEnum.OKAY
+            or type(prompt_response.response) is not str
+        ):
+            raise PromptResponseError(
+                "Failed test step 3: Expected respond to be type(str)"
+            )
+        self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/tool_unit_tests/test_suite_async/tctr_user_prompt/tctr_upload_file_user_prompt.py
+++ b/test_collections/tool_unit_tests/test_suite_async/tctr_user_prompt/tctr_upload_file_user_prompt.py
@@ -1,0 +1,86 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from typing import Optional
+
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+from app.user_prompt_support import (
+    PromptResponse,
+    UploadFile,
+    UploadFilePromptRequest,
+    UserPromptSupport,
+    UserResponseStatusEnum,
+)
+
+
+class TestError(Exception):
+    pass
+
+
+class TCTRUploadFileUserPrompt(TestCase, UserPromptSupport):
+    metadata = {
+        "public_id": "TCTRUploadFileUserPrompt",
+        "version": "1.2.3",
+        "title": "UploadFile User Prompt Unit Test",
+        "description": """This Test Case triggers the upload file user prompt.""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("No-op"),
+            TestStep("Prompt User to Upload a File."),
+        ]
+
+    def __create_custom_upload_file_prompt_request(self) -> UploadFilePromptRequest:
+        prompt = "Please upload of file:"
+        return UploadFilePromptRequest(
+            prompt=prompt,
+            timeout=10,
+        )
+
+    async def setup(self) -> None:
+        logger.info("Upload file usr prompt test case setup.")
+
+    async def execute(self) -> None:
+        logger.info("This test step does nothing.")
+        self.next_step()
+
+        logger.info("This test step prompts the user to upload a file.")
+
+        prompt_request = self.__create_custom_upload_file_prompt_request()
+        prompt_response = await self.send_prompt_request(prompt_request=prompt_request)
+        self.__evaluate_user_response_for_errors(prompt_response)
+
+        self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")
+
+    def handle_uploaded_file(self, file: UploadFile) -> None:
+        """Handles all uploaded files during this test case's execution."""
+        logger.info(f"Received uploaded file: {file.filename}!")
+
+    def __evaluate_user_response_for_errors(
+        self, prompt_response: Optional[PromptResponse]
+    ) -> None:
+        if prompt_response is None:
+            raise TestError("User response returned Null.")
+
+        if prompt_response.status_code == UserResponseStatusEnum.TIMEOUT:
+            raise TestError("User prompt timed out.")
+
+        if prompt_response.status_code == UserResponseStatusEnum.CANCELLED:
+            self.mark_step_failure("User cancelled the prompt.")

--- a/test_collections/tool_unit_tests/test_suite_async/test_runner_test_suite_async.py
+++ b/test_collections/tool_unit_tests/test_suite_async/test_runner_test_suite_async.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestSuite
+
+
+class TestSuiteAsync(TestSuite):
+    metadata = {
+        "public_id": "TestSuiteAsync",
+        "version": "1.2.3",
+        "title": "This is Test Runner Test Suite",
+        "description": "This is Test Runner Test Suite",
+    }
+
+    async def setup(self) -> None:
+        logger.info("This is a test setup")
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test cleanup")

--- a/test_collections/tool_unit_tests/test_suite_chip/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_chip/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .test_suite_chip import TestSuiteChip

--- a/test_collections/tool_unit_tests/test_suite_chip/tctr_chip_log_parsing/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_chip/tctr_chip_log_parsing/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tctr_chip_log_parsing import TCTRChipLogParsing

--- a/test_collections/tool_unit_tests/test_suite_chip/tctr_chip_log_parsing/tctr_chip_log_parsing.py
+++ b/test_collections/tool_unit_tests/test_suite_chip/tctr_chip_log_parsing/tctr_chip_log_parsing.py
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.default_environment_config import default_environment_config
+from app.schemas.test_environment_config import TestEnvironmentConfig
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestStep
+from test_collections.matter.sdk_tests.support.chip.chip_server import ChipServerType
+from test_collections.matter.sdk_tests.support.yaml_tests.models.chip_test import (
+    ChipTest,
+)
+
+
+class TCTRChipLogParsing(ChipTest):
+    metadata = {
+        "public_id": " TCTRChipLogParsing",
+        "version": "1.2.3",
+        "title": "This is Test Case tctr_chip_log_parsing",
+        "description": "This Test Case is built to test the chip-tool log parser",
+    }
+    server_type = ChipServerType.CHIP_APP
+    chip_test_identifier = "Test ID"
+
+    # The config() defined in the "TestCase" base class is unable to return a valid
+    # value because the attributes - test_suite_execution, test_run_execution and
+    # project are not set up. So, override the base class config() to return the
+    # default config.
+    @property
+    def config(self) -> TestEnvironmentConfig:
+        return default_environment_config.copy(deep=True)
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [TestStep("Test Step 1")]
+        self.test_steps = [TestStep("Test Step 2")]
+        self.test_steps = [TestStep("Test Step 3")]
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/tool_unit_tests/test_suite_chip/test_suite_chip.py
+++ b/test_collections/tool_unit_tests/test_suite_chip/test_suite_chip.py
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.models import TestSuite
+
+
+class TestSuiteChip(TestSuite):
+    metadata = {
+        "public_id": "TestSuiteChip",
+        "version": "1.2.3",
+        "title": "This is Chip Tool Unit Test Suite",
+        "description": "This is Chip Tool Unit Test Suite",
+    }

--- a/test_collections/tool_unit_tests/test_suite_exceptions/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_exceptions/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .test_suite_exceptions import TestSuiteExceptions

--- a/test_collections/tool_unit_tests/test_suite_exceptions/tc_exception/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_exceptions/tc_exception/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tc_exception import TCException

--- a/test_collections/tool_unit_tests/test_suite_exceptions/tc_exception/tc_exception.py
+++ b/test_collections/tool_unit_tests/test_suite_exceptions/tc_exception/tc_exception.py
@@ -1,0 +1,73 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class CaseSetupError(Exception):
+    pass
+
+
+class CaseExecuteError(Exception):
+    pass
+
+
+class CaseCleanupError(Exception):
+    pass
+
+
+class TCException(TestCase):
+    metadata = {
+        "public_id": "TCException",
+        "version": "1.2.3",
+        "title": "Test Case with errors",
+        "description": "This Test case can cause errors at all levels",
+    }
+
+    # Static variables to control exceptions
+    error_during_setup = True
+    error_during_execute = True
+    error_during_cleanup = True
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step Pass"),
+            TestStep("Test Step Exception maybe"),
+            TestStep("Test Step Pass"),
+        ]
+
+    async def setup(self) -> None:
+        if self.__class__.error_during_setup:
+            logger.info("Test Suite setup error raised")
+            raise CaseSetupError("Error during setup")
+
+    async def execute(self) -> None:
+        # step 1 pass
+        self.next_step()
+
+        # step 2
+        if self.__class__.error_during_execute:
+            logger.info("Test Suite setup error raised")
+            raise CaseExecuteError("Error during execute")
+
+        self.next_step()
+
+        # step 3 pass
+
+    async def cleanup(self) -> None:
+        if self.__class__.error_during_cleanup:
+            logger.info("Test Suite cleanup error raised")
+            raise CaseCleanupError("Error during cleanup")

--- a/test_collections/tool_unit_tests/test_suite_exceptions/test_suite_exceptions.py
+++ b/test_collections/tool_unit_tests/test_suite_exceptions/test_suite_exceptions.py
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestSuite
+
+
+class SuiteSetupError(Exception):
+    pass
+
+
+class SuiteCleanupError(Exception):
+    pass
+
+
+class TestSuiteExceptions(TestSuite):
+    metadata = {
+        "public_id": "TestSuiteExceptions",
+        "version": "1.2.3",
+        "title": "A Test suite with custom exceptions",
+        "description": "This is Test Suite that can cause exceptions during all phases",
+    }
+
+    # Static variables to control exceptions
+    error_during_setup = True
+    error_during_cleanup = True
+
+    async def setup(self) -> None:
+        if self.__class__.error_during_setup:
+            logger.info("Test Suite setup error raised")
+            raise SuiteSetupError("Error during setup")
+
+    async def cleanup(self) -> None:
+        if self.__class__.error_during_cleanup:
+            logger.info("Test Suite cleanup error raised")
+            raise SuiteCleanupError("Error during cleanup")

--- a/test_collections/tool_unit_tests/test_suite_expected/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_expected/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .test_suite_expected import TestSuiteExpected

--- a/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_error/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_error/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tctr_expected_error import TCTRExpectedError

--- a/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_error/tctr_expected_error.py
+++ b/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_error/tctr_expected_error.py
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TestError(Exception):
+    pass
+
+
+class TCTRExpectedError(TestCase):
+    metadata = {
+        "public_id": "TCTRExpectedError",
+        "version": "1.2.3",
+        "title": "This is Test Case tctr_expected_error",
+        "description": """This Test Case is built to test the test runner,\
+             it is supposed to error out""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for step in self.test_steps:
+            if step.name == "Test Step 2":
+                raise TestError("Error at Test Step 2")
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_fail/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_fail/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tctr_expected_fail import TCTRExpectedFail

--- a/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_fail/tctr_expected_fail.py
+++ b/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_fail/tctr_expected_fail.py
@@ -1,0 +1,46 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCTRExpectedFail(TestCase):
+    metadata = {
+        "public_id": "TCTRExpectedFail",
+        "version": "1.2.3",
+        "title": "This is Test Case tctr_expected_fail",
+        "description": """This Test Case is built to test the test runner,\
+             it is supposed to fail""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for step in self.test_steps:
+            if step.name == "Test Step 2":
+                self.mark_step_failure("Failed Test Step 2")
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_not_applicable/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_not_applicable/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tctr_expected_not_applicable import TCTRExpectedNotApplicable

--- a/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_not_applicable/tctr_expected_not_applicable.py
+++ b/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_not_applicable/tctr_expected_not_applicable.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCTRExpectedNotApplicable(TestCase):
+    metadata = {
+        "public_id": "TCTRExpectedNotApplicable",
+        "version": "1.2.3",
+        "title": "This is Test Case tctr_expected_not_applicable",
+        "description": """This Test Case is built to test the test runner,\
+             it is supposed to pass with one test step marked as not applicable""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for step in self.test_steps:
+            logger.info("Executing something in" + step.name)
+            if step.name == "Test Step 2":
+                step.mark_as_not_applicable("This step is marked as not applicable")
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_pass/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_pass/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tctr_expected_pass import TCTRExpectedPass

--- a/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_pass/tctr_expected_pass.py
+++ b/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_pass/tctr_expected_pass.py
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCTRExpectedPass(TestCase):
+    metadata = {
+        "public_id": "TCTRExpectedPass",
+        "version": "1.2.3",
+        "title": "This is Test Case tctr_expected_pass",
+        "description": """This Test Case is built to test the test runner,\
+             it is supposed to pass""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for step in self.test_steps:
+            logger.info("Executing something in" + step.name)
+            self.next_step()
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/tool_unit_tests/test_suite_expected/test_suite_expected.py
+++ b/test_collections/tool_unit_tests/test_suite_expected/test_suite_expected.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestSuite
+
+
+class TestSuiteExpected(TestSuite):
+    metadata = {
+        "public_id": "TestSuiteExpected",
+        "version": "1.2.3",
+        "title": "This is Test Runner Test Suite",
+        "description": "This is Test Runner Test Suite",
+    }
+
+    async def setup(self) -> None:
+        logger.info("This is a test setup")
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test cleanup")

--- a/test_collections/tool_unit_tests/test_suite_manual/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_manual/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .test_suite_manual import TestSuiteManual

--- a/test_collections/tool_unit_tests/test_suite_manual/tc_manual/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_manual/tc_manual/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tc_manual import TCManual

--- a/test_collections/tool_unit_tests/test_suite_manual/tc_manual/tc_manual.py
+++ b/test_collections/tool_unit_tests/test_suite_manual/tc_manual/tc_manual.py
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Manual Test Case Unit Test."""
+
+from app.test_engine.models import ManualTestCase, TestStep
+
+
+class TCManual(ManualTestCase):
+    metadata = {
+        "public_id": "TCManual",
+        "version": "1.2.3",
+        "title": "A Test Case that must be done manually.",
+        "description": "This Test case will prompt the user if this case"
+        "pass/failed and to upload a log as evidence.",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Manually preform this step first."),
+            TestStep("Manually perform this step second."),
+            TestStep("Manually perform this step last."),
+        ]

--- a/test_collections/tool_unit_tests/test_suite_manual/test_suite_manual.py
+++ b/test_collections/tool_unit_tests/test_suite_manual/test_suite_manual.py
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Manual Test Suite Unit Test."""
+
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestSuite
+
+
+class TestSuiteManual(TestSuite):
+    metadata = {
+        "public_id": "TestSuiteManual",
+        "version": "1.2.3",
+        "title": "A Manual Test Suite",
+        "description": "This is Test Suite that must be executed manually.",
+    }
+
+    async def setup(self) -> None:
+        logger.info("This is a MANUAL test suite setup.")
+
+    async def cleanup(self) -> None:
+        logger.info("This is a MANUAL test suite cleanup.")

--- a/test_collections/tool_unit_tests/test_suite_never_ending/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_never_ending/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .test_suite_never_ending import TestSuiteNeverEnding

--- a/test_collections/tool_unit_tests/test_suite_never_ending/tc_never_ending/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_never_ending/tc_never_ending/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tc_never_ending import TCNeverEnding, TCNeverEndingV2

--- a/test_collections/tool_unit_tests/test_suite_never_ending/tc_never_ending/tc_never_ending.py
+++ b/test_collections/tool_unit_tests/test_suite_never_ending/tc_never_ending/tc_never_ending.py
@@ -1,0 +1,105 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import asyncio
+
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCNeverEnding(TestCase):
+    metadata = {
+        "public_id": "TCNeverEnding",
+        "version": "1.2.3",
+        "title": "Test Case that can sleep forever",
+        "description": "This Test case is built to test the test"
+        "runner's ability to handle CancelledError.",
+    }
+
+    # Static variables to control exceptions
+    never_end_during_setup = False  # type: bool
+    never_end_during_execute = False  # type: bool
+    never_end_during_cleanup = False  # type: bool
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step Pass"),
+            TestStep("Test Step Sleep Infinitely Maybe"),
+            TestStep("Test Step Pass"),
+        ]
+
+    async def setup(self) -> None:
+        if self.never_end_during_setup:
+            logger.info("Test Case setup sleeping forever.")
+            while True:
+                await asyncio.sleep(1)
+
+    async def execute(self) -> None:
+        self.next_step()
+        if self.never_end_during_execute:
+            logger.info("Test Case execute sleeping forever.")
+            while True:
+                await asyncio.sleep(1)
+        self.next_step()
+
+    async def cleanup(self) -> None:
+        if self.never_end_during_cleanup:
+            logger.info("Test Case cleanup sleeping forever.")
+            while True:
+                await asyncio.sleep(1)
+
+
+class TCNeverEndingV2(TestCase):
+    metadata = {
+        "public_id": "TCNeverEndingV2",
+        "version": "1.2.3",
+        "title": "Test Case that can sleep forever V2",
+        "description": "This is a second version for TCNeverEnding Test case. "
+        "No new feature is added to this test case compared to TCNeverEnding."
+        "The goal of this test case is add a second Test Case to the same "
+        "Test Suite TestSuiteNeverEnding.",
+    }
+
+    # Static variables to control exceptions
+    never_end_during_setup = False  # type: bool
+    never_end_during_execute = False  # type: bool
+    never_end_during_cleanup = False  # type: bool
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step Pass"),
+            TestStep("Test Step Sleep Infinitely Maybe"),
+            TestStep("Test Step Pass"),
+        ]
+
+    async def setup(self) -> None:
+        if self.never_end_during_setup:
+            logger.info("Test Case setup sleeping forever.")
+            while True:
+                await asyncio.sleep(1)
+
+    async def execute(self) -> None:
+        self.next_step()
+        if self.never_end_during_execute:
+            logger.info("Test Case execute sleeping forever.")
+            while True:
+                await asyncio.sleep(1)
+        self.next_step()
+
+    async def cleanup(self) -> None:
+        if self.never_end_during_cleanup:
+            logger.info("Test Case cleanup sleeping forever.")
+            while True:
+                await asyncio.sleep(1)

--- a/test_collections/tool_unit_tests/test_suite_never_ending/test_suite_never_ending.py
+++ b/test_collections/tool_unit_tests/test_suite_never_ending/test_suite_never_ending.py
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from asyncio import sleep
+
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestSuite
+
+
+class TestSuiteNeverEnding(TestSuite):
+    metadata = {
+        "public_id": "TestSuiteNeverEnding",
+        "version": "1.2.3",
+        "title": "A Test suite that can sleep forever. ",
+        "description": "This is Test Suite that can sleep forever during all phases",
+    }
+
+    # Static variables to control exceptions
+    never_end_during_setup = False  # type: bool
+    never_end_during_cleanup = False  # type: bool
+
+    async def setup(self) -> None:
+        if self.never_end_during_setup:
+            logger.info("Test Suite setup sleeping forever.")
+            while True:
+                await sleep(1)
+
+    async def cleanup(self) -> None:
+        if self.never_end_during_cleanup:
+            logger.info("Test Suite cleanup sleeping forever.")
+            while True:
+                await sleep(1)

--- a/test_collections/tool_unit_tests/test_suite_pics/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_pics/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .test_suite_pics import TestPICSSuite

--- a/test_collections/tool_unit_tests/test_suite_pics/tc_pics/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_pics/tc_pics/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .tc_pics import TCPics

--- a/test_collections/tool_unit_tests/test_suite_pics/tc_pics/tc_pics.py
+++ b/test_collections/tool_unit_tests/test_suite_pics/tc_pics/tc_pics.py
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCPics(TestCase):
+    metadata = {
+        "public_id": "TC_Pics",
+        "version": "1.2.3",
+        "title": "TC_Pics (Test)",
+        "description": "Test PICS test case for unit testing",
+    }
+
+    @classmethod
+    def pics(cls) -> set[str]:
+        return set(
+            [
+                "AB.C",
+                "AB.C.A0004",
+            ]
+        )
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [TestStep("Test Step 1")]
+        self.test_steps = [TestStep("Test Step 2")]
+        self.test_steps = [TestStep("Test Step 3")]

--- a/test_collections/tool_unit_tests/test_suite_pics/test_suite_pics.py
+++ b/test_collections/tool_unit_tests/test_suite_pics/test_suite_pics.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestSuite
+
+
+class TestPICSSuite(TestSuite):
+    metadata = {
+        "public_id": "TestPICSSuite",
+        "version": "1.2.3",
+        "title": "Test Suite TestPICSSuite",
+        "description": " Test suite for testing PICS",
+    }
+
+    async def setup(self) -> None:
+        logger.info("This is a PICS test suite setup.")
+
+    async def cleanup(self) -> None:
+        logger.info("This is a PICS test suite cleanup.")


### PR DESCRIPTION
## Merge first: https://github.com/project-chip/certification-tool/pull/219

- Copy test collections from backend/test_collections
- Change the backend volume mapping to use test_collections folder from TH