### PR TITLE
[FIX] Exchanging CSA Links to All-Members Section

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -40,10 +40,10 @@ endif::[]
 [cols=".^15%,.^20%,.^10%,.^20%,.^10%,.^25%"]
 |===
 | *Matter Version* | *TH Version*     | *TH image location*                                                                         | *Supporting Documentation*                                                   | *SDK commit* | *Comments*
-| Matter 1.0       | v2.6             | https://drive.google.com/file/d/10YkV4mDulhLoA6RJOKZNNKWhHTH1tOfu/view?usp=drive_link[link] | https://groups.csa-iot.org/wg/matter-csg/document/folder/2947[Causeway Link] | 96c9357      |
-| Matter 1.1       | v2.8.1           | https://drive.google.com/file/d/15fU3L7QE-MNBslf53A_6sFgn1Wq0Pvqd/view?usp=drive_link[link] | https://groups.csa-iot.org/wg/matter-csg/document/folder/2470[Causeway Link] | 5a21d17      |
-| Matter 1.2       | TH-Fall2023      | https://drive.google.com/file/d/1WTjhc7xbYt18RvpABU3_r47uqOLd7NN1/view?usp=drive_link[link] | https://groups.csa-iot.org/wg/matter-csg/document/folder/2756[Causeway Link] | 19771ed      | 
-| Matter 1.3       | v2.10+spring2024 | N/A                                                                                         | https://groups.csa-iot.org/wg/matter-csg/document/folder/3314[Causeway Link] | 11f94c3      | To install, use the tag "v2.10+spring2024" in the instructions of <<fresh_install>>
+| Matter 1.0       | v2.6             | https://drive.google.com/file/d/10YkV4mDulhLoA6RJOKZNNKWhHTH1tOfu/view?usp=drive_link[link] | https://groups.csa-iot.org/wg/members-all/document/folder/2729[Causeway Link] | 96c9357      |
+| Matter 1.1       | v2.8.1           | https://drive.google.com/file/d/15fU3L7QE-MNBslf53A_6sFgn1Wq0Pvqd/view?usp=drive_link[link] | https://groups.csa-iot.org/wg/members-all/document/folder/2730[Causeway Link] | 5a21d17      |
+| Matter 1.2       | TH-Fall2023      | https://drive.google.com/file/d/1WTjhc7xbYt18RvpABU3_r47uqOLd7NN1/view?usp=drive_link[link] | https://groups.csa-iot.org/wg/members-all/document/folder/3045[Causeway Link] | 19771ed      | 
+| Matter 1.3       | v2.10+spring2024 | N/A                                                                                         | https://groups.csa-iot.org/wg/members-all/document/folder/3661[Causeway Link] | 11f94c3      | To install, use the tag "v2.10+spring2024" in the instructions of <<fresh_install>>
 |===
 
 
@@ -118,7 +118,7 @@ The TH tool can be used by any DUT vendor to run the Matter certification tests 
 . Matter SDK Repo github: https://github.com/project-chip/connectedhomeip[https://github.com/project-chip/connectedhomeip]  
 . Matter Test Plans: https://groups.csa-iot.org/wg/members-all/document/30026[Matter Test Plans (Causeway)] / https://github.com/CHIP-Specifications/chip-test-plans[Matter Test Plans (GitHub)]
 . PICS Tool: https://picstool.csa-iot.org/#userguide[PICS Tool - Connectivity Standards Alliance (csa-iot.org)]
-. XML Files: https://groups.csa-iot.org/wg/matter-csg/document/26122
+. XML Files: https://groups.csa-iot.org/wg/members-all/document/31907
 . TEDS Matter tool: https://groups.csa-iot.org/wg/matter-wg/document/28545
 
 
@@ -175,7 +175,7 @@ If the DUT is a commissioner/controller, the Test TH spins an example accessory 
 
 Refer to <<bringing-up-of-matter-node-dut-for-certification-testing, Section 5, Bringing Up of Matter Node (DUT) for Certification Testing>> to bring up the DUT and then proceed with device testing by referring to <<test-configuration, Section 8, Test Configuration>>.
 
-For hobby developers who want to get acquainted with certification tools/process/TC’s, can spin DUT’s using the example apps provided in the SDK. Refer to the instructions to set up one https://groups.csa-iot.org/wg/matter-csg/document/folder/2756[here].
+For hobby developers who want to get acquainted with certification tools/process/TC’s, can spin DUT’s using the example apps provided in the SDK. Refer to the instructions to set up one https://groups.csa-iot.org/wg/members-all/document/folder/3661[here].
 
 TH runs on Ubuntu Server 22.04 LTS (64-bit). The official installation method uses a Raspberry Pi (<<fresh_install>>), but there's an alternative method used in the tool's development that uses a virtual machine instead (<<th-installation-without-a-raspberry-pi>>). Keep in mind that thread networking is not officially supported in VM installations at the moment.
 
@@ -303,13 +303,10 @@ The above command might take a while to get executed, wait for 5-10 minutes and 
 
 The official installation method uses a Raspberry Pi (<<th-installation-on-raspberry-pi, TH Installation on Raspberry Pi>>). **This alternative installation method is targeted for development purpose and it only supports onnetwork pairing mode.**
 
-|===
-|To install TH without using a Raspberry Pi you'll need a machine with Ubuntu Server 22.04 LTS (64-bit). You can <<create-an-ubuntu-virtual-machine, create a virtual machine>> for this purpose, but *be aware that if the host's architecture is not arm64* you'll need to substitute `backend`, `frontend` and <<substitute-the-sdks-docker-image-and-update-sample-apps, the SDK's docker image>> in order for it to work properly.
-|===
+NOTE: To install TH without using a Raspberry Pi you'll need a machine with Ubuntu Server 22.04 LTS (64-bit). You can <<create-an-ubuntu-virtual-machine, create a virtual machine>> for this purpose, but *be aware that if the host's architecture is not arm64* you'll need to substitute `backend`, `frontend` and <<substitute-the-sdks-docker-image-and-update-sample-apps, the SDK's docker image>> in order for it to work properly.
 
-|===
-|Images for linux/amd64 will not always be available in the github registry. So, if necessary, the images needed to be built locally.
-|===
+NOTE: Images for linux/amd64 will not always be available in the github registry. So, if necessary, the images need to be built locally using the following script: +
+`./certification-tool/scripts/build.sh`
 
 ==== Create an Ubuntu virtual machine
 
@@ -1128,7 +1125,7 @@ PICS (_Protocol Implementation Conformance Statement_) is a list of features sup
 
 PICS codes are generated from the Test Plans. The Base.xml file lists all the Core feature PICS from the Matter Base Specifications and the application cluster PICS are listed in the respective TestPlan.xml files. Follow the steps below to generate and upload the PICS files.
 
-. Click on the following link to download the PICS XML files— https://groups.csa-iot.org/wg/matter-csg/document/26122[https://groups.csa-iot.org/wg/matter-csg/document/26122]
+. Click on the following link to download the PICS XML files— https://groups.csa-iot.org/wg/members-all/document/31907[https://groups.csa-iot.org/wg/members-all/document/31907]
 . Click on the following link to use the PICS tool— https://picstool.csa-iot.org/#userguide[PICS Tool v1.6.4 matter 1.0 - Connectivity Standards Alliance (csa-iot.org)]
 . Load the Base.xml file by clicking on the *Browse* option. In case the following error is observed:
 +


### PR DESCRIPTION
## Description
It was reported that some resources may not be accessible to all members of CSA.
The ideia here is to update the links for the `all members` section only and be available for a wider audience.

Fixes: https://github.com/project-chip/certification-tool/issues/264

## Feedback
All the altered links will be listed below.
Please advice against any link exchange present, for whatever reason, if it's not appropriate.

The changes were:
- [(old)2947](https://groups.csa-iot.org/wg/matter-csg/document/folder/2947) -> [(new)2729](https://groups.csa-iot.org/wg/members-all/document/folder/2729)
- [(old) 2470](https://groups.csa-iot.org/wg/matter-csg/document/folder/2470) -> [(new) 2730](https://groups.csa-iot.org/wg/members-all/document/folder/2730)
- [(old) 2756](https://groups.csa-iot.org/wg/matter-csg/document/folder/2756) -> [(new) 3045](https://groups.csa-iot.org/wg/members-all/document/folder/3045)
- [(old) 3314](https://groups.csa-iot.org/wg/matter-csg/document/folder/3314) -> [(new) 3661](https://groups.csa-iot.org/wg/members-all/document/folder/3661)
- [(old) 26122](https://groups.csa-iot.org/wg/matter-csg/document/26122) -> [(new) 31907](https://groups.csa-iot.org/wg/members-all/document/31907)
- [(old) 3314](https://groups.csa-iot.org/wg/matter-csg/document/folder/3314) -> [(new) 3661](https://groups.csa-iot.org/wg/members-all/document/folder/3661)
- [(old) 26122](https://groups.csa-iot.org/wg/matter-csg/document/26122) -> [(new) 31907](https://groups.csa-iot.org/wg/members-all/document/31907)

## Extra
Also, a minor addition was included in the "_TH installation without a Raspberry Pi_" section of the document specifying for the user how to build the backend and frontend locally.
