### PR TITLE
Update User Guide With New Ubuntu Version

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -94,6 +94,7 @@ endif::[]
 | 31          | 10-Jun-2024  | [Apple]Hilton Lima                  | * Updated Test Harness links.
 | 32          | 17-Jun-2024  | [Google] Tennessee Carmel-Veilleux  | * Added an example of an external operational dataset.
 | 33          | 01-Aug-2024  | [Apple] Carolina Lopes              | * Added information about Certification Mode.
+| 34          | 02-Aug-2024  | [Apple] Antonio Melo Jr.            | * Update the Ubuntu mentions to the current supported version
 |===
 
 <<<
@@ -182,7 +183,7 @@ Refer to <<bringing-up-of-matter-node-dut-for-certification-testing, Section 5, 
 
 For hobby developers who want to get acquainted with certification tools/process/TC’s, can spin DUT’s using the example apps provided in the SDK. Refer to the instructions to set up one https://groups.csa-iot.org/wg/members-all/document/folder/3661[here].
 
-TH runs on Ubuntu Server 22.04 LTS (64-bit). The official installation method uses a Raspberry Pi (<<fresh_install>>), but there's an alternative method used in the tool's development that uses a virtual machine instead (<<th-installation-without-a-raspberry-pi>>). Keep in mind that thread networking is not officially supported in VM installations at the moment.
+TH runs on Ubuntu Server 24.04 LTS (64-bit). The official installation method uses a Raspberry Pi (<<fresh_install>>), but there's an alternative method used in the tool's development that uses a virtual machine instead (<<th-installation-without-a-raspberry-pi>>). Keep in mind that thread networking is not officially supported in VM installations at the moment.
 
 [#fresh_install]
 === TH Installation on Raspberry Pi
@@ -212,7 +213,7 @@ If the DUT supports thread transport, an RCP dongle provisioned with a recommend
 **************
 
 . Place the blank SD card into the user’s system USB slot. 
-. Open the https://www.raspberrypi.com/software/[Raspberry Pi Imager] or https://www.balena.io/etcher/[Balena Etcher] tool on the Mac/PC and select the 'Ubuntu Server 22.04 LTS (64-bit)'.
+. Open the https://www.raspberrypi.com/software/[Raspberry Pi Imager] or https://www.balena.io/etcher/[Balena Etcher] tool on the Mac/PC and select the 'Ubuntu Server 24.04 LTS (64-bit)'.
 * Edit the SO custom settings to: 
 ** username: ubuntu
 ** password: raspberrypi
@@ -308,7 +309,7 @@ The above command might take a while to get executed, wait for 5-10 minutes and 
 
 The official installation method uses a Raspberry Pi (<<th-installation-on-raspberry-pi, TH Installation on Raspberry Pi>>). **This alternative installation method is targeted for development purpose and it only supports onnetwork pairing mode.**
 
-NOTE: To install TH without using a Raspberry Pi you'll need a machine with Ubuntu Server 22.04 LTS (64-bit). You can <<create-an-ubuntu-virtual-machine, create a virtual machine>> for this purpose, but *be aware that if the host's architecture is not arm64* you'll need to substitute `backend`, `frontend` and <<substitute-the-sdks-docker-image-and-update-sample-apps, the SDK's docker image>> in order for it to work properly.
+NOTE: To install TH without using a Raspberry Pi you'll need a machine with Ubuntu Server 24.04 LTS (64-bit). You can <<create-an-ubuntu-virtual-machine, create a virtual machine>> for this purpose, but *be aware that if the host's architecture is not arm64* you'll need to substitute `backend`, `frontend` and <<substitute-the-sdks-docker-image-and-update-sample-apps, the SDK's docker image>> in order for it to work properly.
 
 NOTE: Images for linux/amd64 will not always be available in the github registry. So, if necessary, the images need to be built locally using the following script: +
 `./certification-tool/scripts/build.sh`
@@ -326,10 +327,10 @@ Here's an example of how to create a virtual machine for TH using multipass (htt
 |`brew install multipass`
 |===
 
-* Create new VM with Ubuntu Server 22.04 LTS (64-bit) (2 cpu cores, 8G mem and a 50G disk)
+* Create new VM with Ubuntu Server 24.04 LTS (64-bit) (2 cpu cores, 8G mem and a 50G disk)
 
 |===
-|`multipass launch 22.04 -n matter-vm -c 2 -m 8G -d 50G`
+|`multipass launch 24.04 -n matter-vm -c 2 -m 8G -d 50G`
 |===
 
 * SSH into VM


### PR DESCRIPTION
Update all mentions of the Ubuntu version in the user guide for the new current supported Ubuntu 24.04, codename **noble**.