### PR TITLE
Update pkg list for ubuntu2404

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -15,7 +15,10 @@
  * limitations under the License.
 ////
 
-= *Matter Test-Harness User Manual*
+:ubuntu-version: 24.04
+:ubuntu-description: Ubuntu Server {ubuntu-version} LTS (64-bit)
+:th-version: v2.11-beta2+fall2024
+= Matter Test-Harness User Manual: {th-version}
 ifdef::env-github[]
 :tip-caption: :bulb:
 :note-caption: :information_source:
@@ -94,7 +97,12 @@ endif::[]
 | 31          | 10-Jun-2024  | [Apple]Hilton Lima                  | * Updated Test Harness links.
 | 32          | 17-Jun-2024  | [Google] Tennessee Carmel-Veilleux  | * Added an example of an external operational dataset.
 | 33          | 01-Aug-2024  | [Apple] Carolina Lopes              | * Added information about Certification Mode.
-| 34          | 02-Aug-2024  | [Apple] Antonio Melo Jr.            | * Update the Ubuntu mentions to the current supported version
+| 34          | 02-Aug-2024  | [Apple] Antonio Melo Jr.            | * Update the Ubuntu mentions to the current supported version.
+| 35          | 06-Aug-2024  | [Apple] Antonio Melo Jr.            | * Add the TH release version to the front page of the document. +
+                                                                     * Add a warning to TH update when using a different Ubuntu version. +
+                                                                     * Update the OTBR start script parameter. +
+                                                                     * Fix the Thread RCP Firmware link. +
+                                                                     * Add Nrfconnect Sample APPs Firmwares section with link.
 |===
 
 <<<
@@ -183,7 +191,9 @@ Refer to <<bringing-up-of-matter-node-dut-for-certification-testing, Section 5, 
 
 For hobby developers who want to get acquainted with certification tools/process/TC’s, can spin DUT’s using the example apps provided in the SDK. Refer to the instructions to set up one https://groups.csa-iot.org/wg/members-all/document/folder/3661[here].
 
-TH runs on Ubuntu Server 24.04 LTS (64-bit). The official installation method uses a Raspberry Pi (<<fresh_install>>), but there's an alternative method used in the tool's development that uses a virtual machine instead (<<th-installation-without-a-raspberry-pi>>). Keep in mind that thread networking is not officially supported in VM installations at the moment.
+The TH runs on the official *{ubuntu-description}* version. If the TH device happens to be using a different Ubuntu release or other OS, we strongly recommend fresh installing version {ubuntu-description} for reliable results.
+
+The official installation method uses a Raspberry Pi (<<fresh_install>>), but there's an alternative method used in the tool's development that uses a virtual machine instead (<<th-installation-without-a-raspberry-pi>>). Keep in mind that thread networking is not officially supported in VM installations at the moment.
 
 [#fresh_install]
 === TH Installation on Raspberry Pi
@@ -213,7 +223,7 @@ If the DUT supports thread transport, an RCP dongle provisioned with a recommend
 **************
 
 . Place the blank SD card into the user’s system USB slot. 
-. Open the https://www.raspberrypi.com/software/[Raspberry Pi Imager] or https://www.balena.io/etcher/[Balena Etcher] tool on the Mac/PC and select the 'Ubuntu Server 24.04 LTS (64-bit)'.
+. Open the https://www.raspberrypi.com/software/[Raspberry Pi Imager] or https://www.balena.io/etcher/[Balena Etcher] tool on the Mac/PC and select the '{ubuntu-description}'.
 * Edit the SO custom settings to: 
 ** username: ubuntu
 ** password: raspberrypi
@@ -309,7 +319,7 @@ The above command might take a while to get executed, wait for 5-10 minutes and 
 
 The official installation method uses a Raspberry Pi (<<th-installation-on-raspberry-pi, TH Installation on Raspberry Pi>>). **This alternative installation method is targeted for development purpose and it only supports onnetwork pairing mode.**
 
-NOTE: To install TH without using a Raspberry Pi you'll need a machine with Ubuntu Server 24.04 LTS (64-bit). You can <<create-an-ubuntu-virtual-machine, create a virtual machine>> for this purpose, but *be aware that if the host's architecture is not arm64* you'll need to substitute `backend`, `frontend` and <<substitute-the-sdks-docker-image-and-update-sample-apps, the SDK's docker image>> in order for it to work properly.
+NOTE: To install TH without using a Raspberry Pi you'll need a machine with {ubuntu-description}. You can <<create-an-ubuntu-virtual-machine, create a virtual machine>> for this purpose, but *be aware that if the host's architecture is not arm64* you'll need to substitute `backend`, `frontend` and <<substitute-the-sdks-docker-image-and-update-sample-apps, the SDK's docker image>> in order for it to work properly.
 
 NOTE: Images for linux/amd64 will not always be available in the github registry. So, if necessary, the images need to be built locally using the following script: +
 `./certification-tool/scripts/build.sh`
@@ -327,10 +337,10 @@ Here's an example of how to create a virtual machine for TH using multipass (htt
 |`brew install multipass`
 |===
 
-* Create new VM with Ubuntu Server 24.04 LTS (64-bit) (2 cpu cores, 8G mem and a 50G disk)
+* Create new VM with {ubuntu-description} (2 cpu cores, 8G mem and a 50G disk)
 
 |===
-|`multipass launch 24.04 -n matter-vm -c 2 -m 8G -d 50G`
+|`multipass launch {ubuntu-version} -n matter-vm -c 2 -m 8G -d 50G`
 |===
 
 * SSH into VM
@@ -418,13 +428,14 @@ Then run this script in the certification-tool repository +
 
 
 === Update Existing TH
+WARNING: If the Operating System is not the *{ubuntu-description}*, please flash and use a SD card with that Ubuntu release to use this version of Test Harness. Beware that the auto update process below will fail in the case of a different release version.
 
 To update an existing TH environment, follow the instructions below on the terminal.
 
 |===
 |`cd ~/certification-tool` +
 `./scripts/ubuntu/auto-update.sh <Target_Branch/Tag>` +
-`./scripts/start.sh` +
+`./scripts/start.sh`
 
 Wait for 10 mins and open the TH application using the browser
 |===
@@ -761,7 +772,7 @@ If the DUT supports Thread Transport, DUT vendors need to use the OTBR that is s
 Currently the OTBR in the TH works with either the Nordic RCP dongle or SiLabs RCP dongle. Refer to <<instructions-to-flash-the-firmware-nrf52840-rcpdongle, Section 7.1>> to flash the NRF52840 firmware or <<instructions-to-flash-silabs-rcp, Section 7.2>> to flash the SiLabs firmware and get the RCP’s ready. Once the RCP’s are programmed, the user needs to insert the RCP dongle on to the Raspberry Pi running the TH and reboot the Raspberry Pi.
 
 === Instructions to Flash the Firmware NRF52840 RCPDongle
-. Download RCP firmware package from the following link on the user’s system — https://groups.csa-iot.org/wg/matter-csg/document/33943[Thread Firmware Package] 
+. Download RCP firmware package from the following link on the user’s system — https://groups.csa-iot.org/wg/matter-csg/document/34870[Thread RCP Firmware Package]
 . nRF Util is a unified command line utility for Nordic products. For more details, refer to the following link— https://www.nordicsemi.com/Products/Development-tools/nrf-util[https://www.nordicsemi.com/Products/Development-tools/nrf-util]
 . Install the nRF Util dependency in the user’s system using the following command:
 
@@ -787,6 +798,9 @@ Example: +
 . Once the flash is successful, the red LED turns off slowly.
 . Remove the Dongle from the user’s system and connect it to the Raspberry Pi running TH.
 . In case any permission issue occurs during flashing, launch the terminal and retry in sudo mode.
+
+=== Nrfconnect Sample APPs Firmwares to Flash on the NRF52840DK Kit
+The https://groups.csa-iot.org/wg/matter-csg/document/33943[Nrfconnect Sample apps binary Package] is available for download and should be flashed in the development kit NRF52840DK to use it as DUT in the Test-Harness tests.
 
 === Instructions to Flash SiLabs RCP
 
@@ -882,7 +896,7 @@ If any issue occurs while using *otbr_start.sh*, follow the steps below to gener
 .. Run the docker:
 +
 |===
-|`sudo docker run -it --rm --privileged --network otbr -p 8080:80 --sysctl "net.ipv6.conf.all.disable_ipv6=0 net.ipv6.conf.all.forwarding=1" --name otbr -e NAT64=0 --volume /dev/ttyACM0:/dev/ttyACM0 connectedhomeip/otbr:sve2 --radio-url spinel+hdlc+uart:///dev/ttyACM0`
+|`sudo docker run -it --rm --privileged --network otbr -p 8080:80 --sysctl "net.ipv6.conf.all.disable_ipv6=0 net.ipv6.conf.all.forwarding=1" --name otbr -e NAT64=0 --volume /dev/ttyACM0:/dev/ttyACM0 nrfconnect/otbr:9185bda --radio-url spinel+hdlc+uart:///dev/ttyACM0`
 |===
 
 . Generate the Thread form for dataset by entering ‘<Raspberry-Pi IP>:8080’ on the user’s system browser. The OTBR form will be generated as shown below. 

--- a/scripts/ubuntu/1-install-dependencies.sh
+++ b/scripts/ubuntu/1-install-dependencies.sh
@@ -37,8 +37,8 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 # TODO Comment on what dependency is required for:
 packagelist=(
     "docker-ce (>=5:24.0.7-1~ubuntu.22.04~jammy)"     # Test Harness uses Docker
-    "python3-pip (>=22.0.2+dfsg-1ubuntu0.4)"          # Test Harness CLI uses Python              
-    "python3-venv (>=3.10.6-1~22.04)"                 # Test Harness CLI uses Python
+    "python3-pip (>=24.0+dfsg-1ubuntu1)"              # Test Harness CLI uses Python
+    "python3-venv (>=3.12.3-0ubuntu1)"                # Test Harness CLI uses Python
 )
 
 SAVEIFS=$IFS


### PR DESCRIPTION
Updates package list for Ubuntu Server 24.04 LTS
Avoids following error(s)
```
The following packages have unmet dependencies:
 satisfy:command-line : Depends: python3-pip (= 22.0.2+dfsg-1ubuntu0.4) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```