### PR TITLE
Update pkg list for ubuntu2404

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
       - traefik.http.services.${STACK_NAME?Variable not set}-backend.loadbalancer.server.port=80
 
   frontend:
-    image: 'ghcr.io/project-chip/csa-certification-tool-frontend:5ea020e'
+    image: 'ghcr.io/project-chip/csa-certification-tool-frontend:bfe1d52'
     build:
       context: ./frontend
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
           - node.labels.${STACK_NAME?Variable not set}.app-db-data == true
 
   backend:
-    image: 'ghcr.io/project-chip/csa-certification-tool-backend:bbeda31'
+    image: 'ghcr.io/project-chip/csa-certification-tool-backend:fd34786'
 
     ports:
       - "8888:8888"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
           - node.labels.${STACK_NAME?Variable not set}.app-db-data == true
 
   backend:
-    image: 'ghcr.io/project-chip/csa-certification-tool-backend:fd34786'
+    image: 'ghcr.io/project-chip/csa-certification-tool-backend:bbeda31'
 
     ports:
       - "8888:8888"
@@ -97,7 +97,7 @@ services:
       - traefik.http.services.${STACK_NAME?Variable not set}-backend.loadbalancer.server.port=80
 
   frontend:
-    image: 'ghcr.io/project-chip/csa-certification-tool-frontend:bfe1d52'
+    image: 'ghcr.io/project-chip/csa-certification-tool-frontend:5ea020e'
     build:
       context: ./frontend
     labels:

--- a/scripts/ubuntu/1-install-dependencies.sh
+++ b/scripts/ubuntu/1-install-dependencies.sh
@@ -36,9 +36,9 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 
 # TODO Comment on what dependency is required for:
 packagelist=(
-    "docker-ce (>=5:24.0.7-1~ubuntu.22.04~jammy)"     # Test Harness uses Docker
-    "python3-pip (>=22.0.2+dfsg-1ubuntu0.4)"          # Test Harness CLI uses Python              
-    "python3-venv (>=3.10.6-1~22.04)"                 # Test Harness CLI uses Python
+    "docker-ce (>=5:24.0.7-1~ubuntu.22.04~jammy)"  # Test Harness uses Docker
+    "python3-pip (>=24.0+dfsg-1ubuntu1)"           # Test Harness CLI uses Python
+    "python3-venv (>=3.12.3-0ubuntu1)"             # Test Harness CLI uses Python
 )
 
 SAVEIFS=$IFS


### PR DESCRIPTION
Updates package list for Ubuntu Server 24.04 LTS

Before running the auto install script, I ran this:
`sudo apt update && sudo apt upgrade -y`
That command isn't part of the install instructions, but I just figured I'd update the OS.

Got this error:
```
The following packages have unmet dependencies:
 satisfy:command-line : Depends: python3-pip (= 22.0.2+dfsg-1ubuntu0.4) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

If the update command isn't run the error isn't present.

However it might be a good idea to update the package list to the candidate versions that are suggested by the Ubuntu version in use.

Checking the candidates for python3-pip and python3-venv in the Ubuntu Server 24.04 LTS and Ubuntu Server 22.04 LTS environment returns the following (`apt-cache policy python3-pip/venv`):

For Ubuntu Server 24.04 LTS, the candidates are:
`python3-pip: Candidate: 24.0+dfsg-1ubuntu1`
`python3-venv: Candidate: 3.12.3-0ubuntu1`

For Ubuntu Server 22.04 LTS, the candidates are:
`python3-pip: Candidate: 22.0.2+dfsg-1ubuntu0.4`
`python3-venv: Candidate: 3.10.6-1~22.04`

Currently, the versions in the package list match Ubuntu 22.04 but we're now using Ubuntu 24.04, this mismatch causes the above error (given the update command is run, which isn't necessary).

Please advise if this is something worth updating, if anything for consistency.

The update looks like this:
```
packagelist=(
    "docker-ce (>=5:24.0.7-1~ubuntu.22.04~jammy)"  # Test Harness uses Docker
    "python3-pip (>=24.0+dfsg-1ubuntu1)"           # Test Harness CLI uses Python
    "python3-venv (>=3.12.3-0ubuntu1)"             # Test Harness CLI uses Python
)
```