### PR TITLE
[FIX] Improving Python Tests Init Performance 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
     privileged: true
     build:
       context: ./backend
-    command: /start-reload.sh
+    command: bash -c "./prestart.sh; python3 ./app/main.py"
     labels:
       - traefik.enable=true
       - traefik.constraint-label-stack=${TRAEFIK_TAG?Variable not set}


### PR DESCRIPTION
**WIP**
---
Fixes: https://github.com/project-chip/certification-tool/issues/431

This solution exchanges the start-reload script with a direct call of the main.py file from the docker compose file