### PR TITLE
Update user guide final2024

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -212,7 +212,7 @@ The official installation method uses a Raspberry Pi (<<fresh_install>>), but th
 
 There are two ways to obtain the latest TH on Raspberry Pi. Follow the instructions in <<th-installation-on-raspberry-pi, Section 4.1.2, TH Installation on Raspberry Pi>> to install TH from scratch OR if you already have the TH, follow the instructions in <<update-existing-th, Section 4.4, Update Existing TH>> to update the TH.
 
-NOTE:  This instruction applies to the latest version of the Test Harness this document refers to, for earlier versions of the TH please follow the user guide of that specific TH version as for example Ubuntu versions might differ per installation.
+NOTE: This instruction applies to the latest version of the Test Harness this document refers to. For earlier versions of the TH please follow the user guide of that specific TH version as, for example, Ubuntu versions might differ per installation.
 
 ==== *Prerequisites*
 

--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -48,8 +48,6 @@ endif::[]
 | Matter 1.0       | v2.6               | https://drive.google.com/file/d/10YkV4mDulhLoA6RJOKZNNKWhHTH1tOfu/view?usp=drive_link[link] | https://groups.csa-iot.org/wg/members-all/document/folder/2729[Causeway Link] | 96c9357      |
 | Matter 1.1       | v2.8.1             | https://drive.google.com/file/d/15fU3L7QE-MNBslf53A_6sFgn1Wq0Pvqd/view?usp=drive_link[link] | https://groups.csa-iot.org/wg/members-all/document/folder/2730[Causeway Link] | 5a21d17      |
 | Matter 1.2       | TH-Fall2023        | https://drive.google.com/file/d/1WTjhc7xbYt18RvpABU3_r47uqOLd7NN1/view?usp=drive_link[link] | https://groups.csa-iot.org/wg/members-all/document/folder/3045[Causeway Link] | 19771ed      | 
-| Matter 1.3       | v2.10+spring2024   | N/A                                                                                         | https://groups.csa-iot.org/wg/members-all/document/folder/3661[Causeway Link] | 11f94c3      | To install, use the tag "v2.10+spring2024" in the instructions of <<fresh_install>>
-| Matter 1.3       | v2.10.1+spring2024 | N/A                                                                                         | https://groups.csa-iot.org/wg/members-all/document/folder/3314[Causeway Link] | fb2c0e5      | To install, use the tag "v2.10.1+spring2024" in the instructions of <<fresh_install>>
 | Matter 1.3       | v2.10.2+spring2024 | N/A                                                                                         | https://groups.csa-iot.org/wg/members-all/document/folder/3314[Causeway Link] | 50bcad1      | To install, use the tag "v2.10.2+spring2024" in the instructions of <<fresh_install>>
 | Matter 1.4       | v2.11+fall2024     | N/A                                                                                         | https://groups.csa-iot.org/wg/members-all/document/folder/4120[Causeway Link] | f2e5de7      | To install, use the tag "v2.11+fall2024" in the instructions of <<fresh_install>>
 |===
@@ -213,6 +211,8 @@ The official installation method uses a Raspberry Pi (<<fresh_install>>), but th
 === TH Installation on Raspberry Pi
 
 There are two ways to obtain the latest TH on Raspberry Pi. Follow the instructions in <<th-installation-on-raspberry-pi, Section 4.1.2, TH Installation on Raspberry Pi>> to install TH from scratch OR if you already have the TH, follow the instructions in <<update-existing-th, Section 4.4, Update Existing TH>> to update the TH.
+
+NOTE:  This instruction applies to the latest version of the Test Harness this document refers to, for earlier versions of the TH please follow the user guide of that specific TH version as for example Ubuntu versions might differ per installation.
 
 ==== *Prerequisites*
 


### PR DESCRIPTION
### What Changed
Removed  several references to Matter 1.3 version and in the end having just one
Added a note that the UG guide instructions applies to the latest version of the Matter.

### Related Issue
https://github.com/project-chip/certification-tool/issues/474