### PR TITLE
docs: Update Ubuntu version to 24.04.1 in TH User Guide

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -15,7 +15,7 @@
  * limitations under the License.
 ////
 
-:ubuntu-version: 24.04
+:ubuntu-version: 24.04.1
 :ubuntu-description: Ubuntu Server {ubuntu-version} LTS (64-bit)
 :th-version: v2.11+fall2024
 = Matter Test-Harness User Manual: {th-version}


### PR DESCRIPTION
Update the Ubuntu version reference to 24.04.1 as this is now the only available option in the Raspberry Pi Imager for Ubuntu Server 24.04 LTS.