### PR TITLE
[FIX] Update Network Check Method In Installation Script

### DIFF
--- a/scripts/ubuntu/1.1-install-docker-repository.sh
+++ b/scripts/ubuntu/1.1-install-docker-repository.sh
@@ -29,21 +29,21 @@ print_script_step "Verify docker.download.com is reachable"
 # Docker Package Repo (network randomly fails after service restarts).
 for i in {1..5}
 do
-	timeout 2 bash -c "(echo >/dev/tcp/docker.download.com/80) &>/dev/null"
-	retVal=$?
-	if [ $retVal -eq 0 ]; then
-		echo "The docker.download.com is reacheable"
-		break
-	else
-		echo "The docker.download.com is unreachable for try $i"
-		sleep $(expr $i \* 2)
-	fi
+    timeout 2 bash -c "(echo >/dev/tcp/docker.download.com/80) &>/dev/null"
+    retVal=$?
+    if [ $retVal -eq 0 ]; then
+        echo "The docker.download.com is reacheable"
+        break
+    else
+        echo "The docker.download.com is unreachable for try $i"
+        sleep $(expr $i \* 2)
+    fi
 
-	if [ "$i" -eq '5' ]; then
-		echo "Failed to stablish connection with the docker.download.com service."
-		echo "Please verify your connection or try again later."
-		exit 1
-	fi
+    if [ "$i" -eq '5' ]; then
+        echo "Failed to stablish connection with the docker.download.com service."
+        echo "Please verify your connection or try again later."
+        exit 1
+    fi
 done
 
 set -e

--- a/scripts/ubuntu/1.1-install-docker-repository.sh
+++ b/scripts/ubuntu/1.1-install-docker-repository.sh
@@ -23,33 +23,30 @@ source "$SCRIPT_DIR/utils.sh"
 
 print_start_of_script
 
+set +e
 print_script_step "Verify docker.download.com is reachable"
 # Verify docker.download.com is reachable before attempting to install the
 # Docker Package Repo (network randomly fails after service restarts).
-# A ping will be attempted and retried in increments of 1 second before
-# a 5 minute timeout.
-timeout 300s bash -c '
-start_time=$(date)
-echo "Ping started at: $start_time"
-while :; do
-  if ping -c 1 docker.download.com | grep -q "1 received"; then
-    echo "Ping docker.download.com successful"
-    end_time=$(date)
-    echo "Ping ended at: $end_time"
-    echo "Ping duration: $(($(date +%s) - $(date -d "$start_time" +%s))) seconds"
-    break
-  fi
-  echo "Ping docker.download.com failed, retrying..."
-  sleep 1
-done
-if [ $? -eq 124 ]; then
-  end_time=$(date)
-  echo "docker.download.com: Timeout reached"
-  echo "Ping ended at: $end_time"
-  echo "Ping duration: $(($(date +%s) - $(date -d "$start_time" +%s))) seconds"
-fi
-'
+for i in {1..5}
+do
+	timeout 2 bash -c "(echo >/dev/tcp/docker.download.com/80) &>/dev/null"
+	retVal=$?
+	if [ $retVal -eq 0 ]; then
+		echo "The docker.download.com is reacheable"
+		break
+	else
+		echo "The docker.download.com is unreachable for try $i"
+		sleep $(expr $i \* 2)
+	fi
 
+	if [ "$i" -eq '5' ]; then
+		echo "Failed to stablish connection with the docker.download.com service."
+		echo "Please verify your connection or try again later."
+		exit 1
+	fi
+done
+
+set -e
 # Reference link: https://docs.docker.com/engine/install/ubuntu/
 print_script_step "Add Docker's official GPG key"
 sudo apt-get update -y


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/491
---

Updating the docker's network service connectivity check on installation script exchanging the ping usage for a direct TCP package test.

As per the issue associated above, the ping tool uses the ICMP protocol that may be blocked by the local firewall of some users. The benefit of using TCP package exchange is that no tool is required to be installed in the Raspberry Pi's OS since it's a resource already present in the system.

For the logic of the check, the connectivity is tested five times against the docker's download service URL, waiting a few seconds before trying again and cancelling in case of failure.