### PR TITLE
Updating backend HASH

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
           - node.labels.${STACK_NAME?Variable not set}.app-db-data == true
 
   backend:
-    image: 'ghcr.io/project-chip/csa-certification-tool-backend:40e26c9'
+    image: 'ghcr.io/project-chip/csa-certification-tool-backend:b845de3'
 
     ports:
       - "8888:8888"


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/455

---
Update the Backend HASH to fix the issue of connection failure of backend service when the device has no internet access.