### PR TITLE
docs: add "timeout" to Test Parameters section

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -1250,6 +1250,15 @@ Only one of the following parameter is allowed, also when one of them is configu
 +
 WARNING: This is an invalid configuration. TH will not accept both parameters set at the same time.
 
+.. Overwrite the default timeout. Value in [s]:
++
+[source,xml]
+----
+"test_parameters": {
+  "timeout": 300
+}
+----
+
 On completion of the "network" and the "dut_config" configuration, select the *Update* and then *Create* button to create the Test Project. 
 
 


### PR DESCRIPTION
Add the parameter "timeout" to Test Parameters section.

I'm not sure how to recreate the PDF file.