### PR TITLE
[Fix] Install Script Error Check

### DIFF
--- a/scripts/ubuntu/auto-update.sh
+++ b/scripts/ubuntu/auto-update.sh
@@ -19,4 +19,11 @@ UBUNTU_SCRIPT_DIR="$ROOT_DIR/scripts/ubuntu"
 LOG_FILENAME=$(date +"log-ubuntu-auto-update_%F-%H-%M-%S")
 LOG_PATH="$ROOT_DIR/logs/$LOG_FILENAME"
 
-$UBUNTU_SCRIPT_DIR/internal-auto-update.sh $* | tee $LOG_PATH
+OUTPUT=$($UBUNTU_SCRIPT_DIR/internal-auto-update.sh $* 2>&1)
+RETURN_CODE=$?
+
+echo "$OUTPUT" | tee $LOG_PATH
+
+if [ $RETURN_CODE != 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Description 
The installation of TH is continuing the process even when an error has been encountered.

As we can see below, the install script shows the final step (asking the user to reboot the device) even so there are errors just before on the output:
![Screenshot 2025-01-24 at 13 57 09](https://github.com/user-attachments/assets/296b8118-3c65-4027-84aa-4183ef78c2de)

## The Cause
That's happening because of there's no error checking and return in the `auto-update.sh` script, so the script calling it (`internal-auto-update.sh`) verify an error that will never happen.

## Solution
Since the `auto-update.sh` uses `tee` command to redirect the installation output to a file, we can't just call the `verify_return_code` from the `/certification-tool/scripts/utils.sh` file. So the solution was to store the output from the command, store the return code, redirect the output to the log file and then verify the return code to return with error or not.
We may see the result below:
<img width="1137" alt="Screenshot 2025-02-11 at 15 13 01" src="https://github.com/user-attachments/assets/e38f4329-ed0a-461a-9497-15667d171622" />

**PS:**
There're other two files with the `tee` redirect, but there's no need to change them since those are the `auto-install.sh` files that they're not called by other scripts in the moment