### PR TITLE
Improve TH start script

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -97,7 +97,7 @@ if [ "$FRONTEND_DEV" = true ] ; then
 else
     echo -n "Waiting for frontend to start"
     CHECK_FRONTEND_SERVICE="docker compose exec frontend curl --fail -s --output /dev/null http://localhost:4200"
-    until $CHECK_FRONTEND_SERVICE >> frontend_service_start.log 2>&1 
+    until $CHECK_FRONTEND_SERVICE >> logs/frontend_service_start.log 2>&1 
     do
         echo -n "."
         sleep 5
@@ -111,7 +111,7 @@ if [ "$BACKEND_DEV" = true ] ; then
 else
     echo -n "Waiting for backend to start"
     CHECK_BACKEND_SERVICE="docker compose exec backend curl --fail -s --output /dev/null http://localhost/docs"
-    until $CHECK_BACKEND >> backend_service_start.log 2>&1
+    until $CHECK_BACKEND >> logs/backend_service_start.log 2>&1
     do
         echo -n "."
         sleep 5

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -96,7 +96,8 @@ if [ "$FRONTEND_DEV" = true ] ; then
     echo "!!!! Manually start frontend by connecting to the frontend container"
 else
     echo -n "Waiting for frontend to start"
-    until docker compose exec frontend curl --fail -s --output /dev/null http://localhost:4200
+    CHECK_FRONTEND_SERVICE="docker compose exec frontend curl --fail -s --output /dev/null http://localhost:4200"
+    until $CHECK_FRONTEND_SERVICE >> frontend_service_start.log 2>&1 
     do
         echo -n "."
         sleep 5
@@ -109,7 +110,8 @@ if [ "$BACKEND_DEV" = true ] ; then
     echo "!!!! Manually start backend by connecting to the backend container"
 else
     echo -n "Waiting for backend to start"
-    until docker compose exec backend curl --fail -s --output /dev/null http://localhost/docs
+    CHECK_BACKEND_SERVICE="docker compose exec backend curl --fail -s --output /dev/null http://localhost/docs"
+    until $CHECK_BACKEND >> backend_service_start.log 2>&1
     do
         echo -n "."
         sleep 5


### PR DESCRIPTION

- When wait FE and BE starts: Send standard and error outputs to a log file

- Start script log:
<img width="471" alt="Screenshot 2025-02-27 at 16 40 45" src="https://github.com/user-attachments/assets/0900a235-bfa6-4e5f-924b-2393941f9b42" />

- Frontend log file:
<img width="522" alt="Screenshot 2025-02-27 at 16 41 31" src="https://github.com/user-attachments/assets/652e1d59-27ec-4d86-ae99-5ae714b19872" />
