### PR TITLE
Add poetry self update for cli installation

### DIFF
--- a/scripts/update-setup-cli-dependencies.sh
+++ b/scripts/update-setup-cli-dependencies.sh
@@ -26,6 +26,7 @@ print_start_of_script
 print_script_step "Running Poetry install"
 source ~/.profile #ensure poetry is in path
 cd $ROOT_DIR/cli
+poetry self update
 poetry install --no-root
 
 print_end_of_script


### PR DESCRIPTION
### What Changed
Add `poetry self update` instruction since many user are getting this error while updating TH version:
```
 The Poetry configuration is invalid:
  - The fields ['authors', 'description', 'name', 'version'] are required in package mode.
```