### PR TITLE
[Camera] Map ports for certification-tool-backend container to listen H.264 packets

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
     ports:
       - "8888:8888"
       - "50000:50000"
+      - "5000:5000/udp" #To receive H264 packets from camera-controller
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /usr/bin/docker:/usr/bin/docker


### PR DESCRIPTION
#### Problem
* For the TestHarness
* This PR adds expose ports of certification-tool-backend container to listen to H.264 packets produce by camera-controller.
This is required to forward the H.264 packets to the frontend client.

#### Change overview
* Test Harness provides H.264 frames from camera-controller SDK.
* The camera-controller is opening H.264 packets to the TH. 

#### Testing
* Excute TestHarness and check WebRTC Requestor/Provider operations
* Install apk file on Android phone such as Galaxy and Pixel
* SmartThings App and Hub can commission camera-app and It is possible to test full automation
