### PR TITLE
Proxy-friendly version of install-docker-repository

### DIFF
--- a/scripts/ubuntu/1.1-install-docker-repository.sh
+++ b/scripts/ubuntu/1.1-install-docker-repository.sh
@@ -31,7 +31,7 @@ for i in {1..5}
 do
     status_code=$(sudo curl -sS -o /dev/null -w "%{http_code}" --connect-timeout 1 "https://download.docker.com" ${https_proxy+--proxy $https_proxy} )
     if [ $? -eq 0 ] && [ "$status_code" -lt 400 ]; then
-        echo "The download.docker.com is reacheable"
+        echo "The download.docker.com is reachable"
         break
     else
         echo "The download.docker.com is unreachable for try $i"

--- a/scripts/ubuntu/1.1-install-docker-repository.sh
+++ b/scripts/ubuntu/1.1-install-docker-repository.sh
@@ -24,23 +24,22 @@ source "$SCRIPT_DIR/utils.sh"
 print_start_of_script
 
 set +e
-print_script_step "Verify docker.download.com is reachable"
-# Verify docker.download.com is reachable before attempting to install the
+print_script_step "Verify download.docker.com is reachable"
+# Verify download.docker.com is reachable before attempting to install the
 # Docker Package Repo (network randomly fails after service restarts).
 for i in {1..5}
 do
-    timeout 2 bash -c "(echo >/dev/tcp/docker.download.com/80) &>/dev/null"
-    retVal=$?
-    if [ $retVal -eq 0 ]; then
-        echo "The docker.download.com is reacheable"
+    status_code=$(sudo curl -sS -o /dev/null -w "%{http_code}" --connect-timeout 1 "https://download.docker.com" ${https_proxy+--proxy $https_proxy} )
+    if [ $? -eq 0 ] && [ "$status_code" -lt 400 ]; then
+        echo "The download.docker.com is reacheable"
         break
     else
-        echo "The docker.download.com is unreachable for try $i"
+        echo "The download.docker.com is unreachable for try $i"
         sleep $(expr $i \* 2)
     fi
 
     if [ "$i" -eq '5' ]; then
-        echo "Failed to stablish connection with the docker.download.com service."
+        echo "Failed to stablish connection with the download.docker.com service."
         echo "Please verify your connection or try again later."
         exit 1
     fi
@@ -52,7 +51,7 @@ print_script_step "Add Docker's official GPG key"
 sudo apt-get update -y
 sudo apt-get install ca-certificates curl -y
 sudo install -m 0755 -d /etc/apt/keyrings
-sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc ${https_proxy+--proxy $https_proxy}
 sudo chmod a+r /etc/apt/keyrings/docker.asc
 
 print_script_step "Add the repository to Apt sources"

--- a/scripts/ubuntu/1.1-install-docker-repository.sh
+++ b/scripts/ubuntu/1.1-install-docker-repository.sh
@@ -39,7 +39,7 @@ do
     fi
 
     if [ "$i" -eq '5' ]; then
-        echo "Failed to stablish connection with the download.docker.com service."
+        echo "Failed to establish connection with the download.docker.com service."
         echo "Please verify your connection or try again later."
         exit 1
     fi

--- a/scripts/ubuntu/1.1-install-docker-repository.sh
+++ b/scripts/ubuntu/1.1-install-docker-repository.sh
@@ -23,13 +23,18 @@ source "$SCRIPT_DIR/utils.sh"
 
 print_start_of_script
 
+# Expands to `--proxy <url>` when https_proxy is set, empty otherwise.
+# Unquoted at use sites so it splits into 0 or 2 args. Passed as args (not env)
+# because sudo strips https_proxy by default.
+proxy_opt="${https_proxy+--proxy $https_proxy}"
+
 set +e
 print_script_step "Verify download.docker.com is reachable"
 # Verify download.docker.com is reachable before attempting to install the
 # Docker Package Repo (network randomly fails after service restarts).
 for i in {1..5}
 do
-    status_code=$(sudo curl -sS -o /dev/null -w "%{http_code}" --connect-timeout 1 "https://download.docker.com" ${https_proxy+--proxy $https_proxy} )
+    status_code=$(sudo curl -sS -o /dev/null -w "%{http_code}" --connect-timeout 1 "https://download.docker.com" $proxy_opt)
     if [ $? -eq 0 ] && [ "$status_code" -lt 400 ]; then
         echo "The download.docker.com is reachable"
         break
@@ -51,7 +56,7 @@ print_script_step "Add Docker's official GPG key"
 sudo apt-get update -y
 sudo apt-get install ca-certificates curl -y
 sudo install -m 0755 -d /etc/apt/keyrings
-sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc ${https_proxy+--proxy $https_proxy}
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc $proxy_opt
 sudo chmod a+r /etc/apt/keyrings/docker.asc
 
 print_script_step "Add the repository to Apt sources"


### PR DESCRIPTION
Previously the script would not work in some proxy environments.
With this change, it is possible to have proxy set in "https_proxy" environment variable.
