### PR TITLE
[FIX] User Guide Broken Images

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -126,7 +126,7 @@ endif::[]
                                                                      * Added the platform certification configuration section. +
                                                                      * Updated the docker command in Factory-reset the DUT section +
                                                                      * Added the Wi-Fi PAF section supported by Matter 1.4.2 +
-                                                                     * Fixed links format and URLs
+                                                                     * Fixed links format and URLs +
                                                                      * Fixed adoc's broken images removing the absolute path imagesdir
 |===
 


### PR DESCRIPTION
Fixes https://github.com/project-chip/certification-tool/issues/695

---

The images from the User Guide are not being presented while accessing through the site (e.g. [UG GitHub page](https://github.com/project-chip/certification-tool/blob/v2.13%2Bsummer2025/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc#31-th-layout)).

This change removes the absolute path configured with the `:imagesdir:` from ADOC file to force the file to use the relative path and correctly access the `images` folder.

**Example of the result may be verified below:**
<img width="801" height="650" alt="Screenshot 2025-08-04 at 10 30 05" src="https://github.com/user-attachments/assets/f5fa7130-891f-4f97-9584-00261c2bd65f" />

---

**Also:** correcting the table's link broken format and URL and adding the missing entries from the revision history.