### PR TITLE
[Camera] Add pushav-service to proxy https requests by skipping ssl verification

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
 
   proxy:
     image: traefik:v2.2
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "80:80"
       - "8090:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./backend:/app
+      - ./traefik_dynamic.yml:/etc/traefik/traefik_dynamic.yml
     command:
       # Enable Docker in Traefik, so that it reads labels from Docker services
       - --providers.docker
@@ -34,6 +35,12 @@ services:
       - --providers.docker.constraints=Label(`traefik.constraint-label-stack`, `${TRAEFIK_TAG?Variable not set}`)
       # Do not expose all Docker services, only the ones explicitly exposed
       - --providers.docker.exposedbydefault=false
+      # Enable file provider for push-av server
+      - --providers.file.filename=/etc/traefik/traefik_dynamic.yml
+      # insecureSkipVerify is enabled for push_av_server as it uses a self-signed certificate.
+      # This ensures Traefik can proxy requests HTTP -> HTTPS without failing certificate validation.
+      # service specific transport is not supported in v2.2 and was introduced in v2.4 hence enabling it here.
+      - --serversTransport.insecureSkipVerify=true
       # Enable the access log, with HTTP requests
       - --accesslog
       # Enable the Traefik log, for configurations and errors

--- a/traefik_dynamic.yml
+++ b/traefik_dynamic.yml
@@ -9,7 +9,7 @@ http:
     pushav-service:
       loadBalancer:
         servers:
-          - url: "https://172.17.0.1:1234"
+          - url: "https://host.docker.internal:1234"
   middlewares:
     pushav-stripprefix:
       stripPrefix:

--- a/traefik_dynamic.yml
+++ b/traefik_dynamic.yml
@@ -1,0 +1,17 @@
+http:
+  routers:
+    pushav-router:
+      rule: "PathPrefix(`/pushav`)"
+      service: pushav-service
+      middlewares:
+        - pushav-stripprefix
+  services:
+    pushav-service:
+      loadBalancer:
+        servers:
+          - url: "https://172.17.0.1:1234"
+  middlewares:
+    pushav-stripprefix:
+      stripPrefix:
+        prefixes:
+          - "/pushav"


### PR DESCRIPTION
This PR adds a pushav-service to proxy http->https requests to push_av_server. The server runs in chip-cert-bins and is started during TC runtime.
This is needed as push_av_server uses a self-signed certificate and browser cannot directly invoke api calls to the server.
Through this change, the frontend communicates with traefik over HTTP, and Traefik forwards the request to the server over HTTPs. `insecureSkipVerify=true` is required to let the Traefik skip ssl validation.