### PR TITLE
Fix fresh installation issue in fall2025 version

### DIFF
--- a/scripts/ubuntu/1-install-dependencies.sh
+++ b/scripts/ubuntu/1-install-dependencies.sh
@@ -39,7 +39,7 @@ readarray packagelist < "$UBUNTU_SCRIPT_DIR/package-dependency-list.txt"
 SAVEIFS=$IFS
 IFS=$(echo -en "\r")
 for package in ${packagelist[@]}; do
-  print_script_step "Instaling package: ${package[@]}"
+  print_script_step "Installing package: ${package[@]}"
 
   # Special handling for docker-ce to avoid version 29.x
   if [[ "${package%%[[:space:]]}" == docker-ce* ]]; then

--- a/scripts/ubuntu/1-install-dependencies.sh
+++ b/scripts/ubuntu/1-install-dependencies.sh
@@ -42,9 +42,9 @@ for package in ${packagelist[@]}; do
   print_script_step "Instaling package: ${package[@]}"
 
   # Special handling for docker-ce to avoid version 29.x
-  if [[ ${package[@]} == docker-ce* ]]; then
+  if [[ "${package%%[[:space:]]}" == docker-ce* ]]; then
     # Get the latest version that is not 29.x
-    DOCKER_VERSION=$(apt-cache madison docker-ce | awk '{print $3}' | grep -v '^5:29\.' | head -1)
+    DOCKER_VERSION=$(apt-cache madison docker-ce | awk '$3 !~ /^5:29\./ {print $3; exit}')
     if [ -n "$DOCKER_VERSION" ]; then
       print_script_step "Installing docker-ce version $DOCKER_VERSION (excluding 29.x)"
       sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades docker-ce=$DOCKER_VERSION docker-ce-cli=$DOCKER_VERSION containerd.io
@@ -54,7 +54,7 @@ for package in ${packagelist[@]}; do
       exit 1
     fi
   else
-    sudo DEBIAN_FRONTEND=noninteractive apt-get satisfy ${package[@]} -y --allow-downgrades
+    sudo DEBIAN_FRONTEND=noninteractive apt-get satisfy "${package%%[[:space:]]}" -y --allow-downgrades
   fi
 done
 IFS=$SAVEIFS 

--- a/scripts/ubuntu/1-install-dependencies.sh
+++ b/scripts/ubuntu/1-install-dependencies.sh
@@ -40,7 +40,22 @@ SAVEIFS=$IFS
 IFS=$(echo -en "\r")
 for package in ${packagelist[@]}; do
   print_script_step "Instaling package: ${package[@]}"
-  sudo DEBIAN_FRONTEND=noninteractive apt-get satisfy ${package[@]} -y --allow-downgrades
+
+  # Special handling for docker-ce to avoid version 29.x
+  if [[ ${package[@]} == docker-ce* ]]; then
+    # Get the latest version that is not 29.x
+    DOCKER_VERSION=$(apt-cache madison docker-ce | awk '{print $3}' | grep -v '^5:29\.' | head -1)
+    if [ -n "$DOCKER_VERSION" ]; then
+      print_script_step "Installing docker-ce version $DOCKER_VERSION (excluding 29.x)"
+      sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades docker-ce=$DOCKER_VERSION docker-ce-cli=$DOCKER_VERSION containerd.io
+      sudo apt-mark hold docker-ce docker-ce-cli
+    else
+      echo "ERROR: No suitable docker-ce version found (excluding 29.x)"
+      exit 1
+    fi
+  else
+    sudo DEBIAN_FRONTEND=noninteractive apt-get satisfy ${package[@]} -y --allow-downgrades
+  fi
 done
 IFS=$SAVEIFS 
 

--- a/scripts/ubuntu/package-dependency-list.txt
+++ b/scripts/ubuntu/package-dependency-list.txt
@@ -1,3 +1,3 @@
-docker-ce (>=5:24.0.7-1~ubuntu.22.04~jammy)
+docker-ce (>=5:24.0.7-1~ubuntu.22.04~jammy) (<<5:28.0.0)
 python3-pip (>=24.0+dfsg-1ubuntu1)
 python3-venv (>=3.12.3-0ubuntu1)

--- a/scripts/ubuntu/package-dependency-list.txt
+++ b/scripts/ubuntu/package-dependency-list.txt
@@ -1,3 +1,3 @@
-docker-ce=5:27.3.1-1~ubuntu.22.04~jammy
+docker-ce (<< 5:29.0)
 python3-pip (>=24.0+dfsg-1ubuntu1)
 python3-venv (>=3.12.3-0ubuntu1)

--- a/scripts/ubuntu/package-dependency-list.txt
+++ b/scripts/ubuntu/package-dependency-list.txt
@@ -1,3 +1,3 @@
-docker-ce (>=5:24.0.7-1~ubuntu.22.04~jammy) (<<5:28.0.0)
+docker-ce=5:27.3.1-1~ubuntu.22.04~jammy
 python3-pip (>=24.0+dfsg-1ubuntu1)
 python3-venv (>=3.12.3-0ubuntu1)


### PR DESCRIPTION
### What changed
 Docker 29.0.0 requires API v1.44 minimum, breaking Traefik's ability to discover containers. Modified installation script to automatically select latest Docker version < 29.x and hold it to prevent auto-upgrade.

 - Modified scripts/ubuntu/1-install-dependencies.sh to detect docker-ce in package list and install latest non-29.x version explicitly
  - Uses apt-cache madison to find most recent Docker version excluding 29.x series (currently installs 28.5.2)
  - Applies apt-mark hold to prevent automatic upgrades to Docker 29.x
  - Maintains backward compatibility with package-dependency-list.txt
  
### Related issue
https://github.com/project-chip/certification-tool/issues/788

### Testing
I performed a fresh TH installation without any errors.