### PR TITLE
[FIX] User Guide Fix For Matter 1.6 TE1

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -128,7 +128,7 @@ endif::[]
                                                                      * Added the platform certification configuration section. +
                                                                      * Updated the docker command in Factory-reset the DUT section +
                                                                      * Added the Wi-Fi PAF section supported by Matter 1.4.2.
-| 48          | 10-Nov-2025  | [Apple]Romulo Quidute, [Apple]Antonio Melo| * Changes for v2.14+fall2025 version. +
+| 48          | 10-Nov-2025  | [Apple]Romulo Quidute, [Apple]Antonio Melo| * Changes for v2.14+fall2025 version.
 | 49          | 14-Nov-2025  | [Apple]Antonio Melo Jr.             | * Adding the Side Load feature instructions to the custom Test Cases section. +
                                                                      * Fixing the Causeway links in the references section. +
                                                                      * Fixing the REPL command in the Matter Python REPL section.

--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -131,8 +131,8 @@ endif::[]
 | 48          | 10-Nov-2025  | [Apple]Romulo Quidute, [Apple]Antonio Melo| * Changes for v2.14+fall2025 version. +
 | 49          | 14-Nov-2025  | [Apple]Antonio Melo Jr.             | * Adding the Side Load feature instructions to the custom Test Cases section. +
                                                                      * Fixing the Causeway links in the references section. +
-                                                                     * Using the TH version variable in the Test-Harness Links table. +
                                                                      * Fixing the REPL command in the Matter Python REPL section.
+| 50          | 18-Nov-2025  | [Apple]Antonio Melo Jr.             | * Using the TH version variable in the Test-Harness Links table.
 |===
 
 <<<
@@ -458,6 +458,7 @@ Custom Python files folder are located at:
 
 .Test-Harness displaying the custom tests.
 image::images/img_60.png[]
+
 
 [NOTE]
 .*Experimenting with Test Cases:*

--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -52,7 +52,7 @@ endif::[]
 | Matter 1.4.1     | v2.12+spring2025   | N/A                                                                                         | https://groups.csa-iot.org/wg/members-all/document/folder/4497[Causeway Link] | 91eab26      | To install, use the tag "v2.12+spring2025" in the instructions of <<fresh_install>>
 | Matter 1.4.2     | v2.13+summer2025   | N/A                                                                                         | https://groups.csa-iot.org/wg/members-all/document/folder/4651[Causeway Link] | 1b2b3fd      | To install, use the tag "v2.13+summer2025" in the instructions of <<fresh_install>>
 | Matter 1.5       | v2.14+fall2025     | N/A                                                                                         | https://groups.csa-iot.org/wg/members-all/document/folder/4825[Causeway Link] | ca9d111      | To install, use the tag "v2.14+fall2025" in the instructions of <<fresh_install>>
-| Matter 1.6       | v2.15-beta1+winter2025     | N/A                                                                                         | TBD | TBD      | To install, use the tag "v2.15-beta1+winter2025" in the instructions of <<fresh_install>>
+| Matter 1.6       | {th-version}   | N/A                                                                                             | TBD | TBD      | To install, use the branch "{th-version}" in the instructions of <<fresh_install>>
 |===
 
 
@@ -128,7 +128,11 @@ endif::[]
                                                                      * Added the platform certification configuration section. +
                                                                      * Updated the docker command in Factory-reset the DUT section +
                                                                      * Added the Wi-Fi PAF section supported by Matter 1.4.2.
-| 48          | 10-Nov-2025  | [Apple]Romulo Quidute, [Apple]Antonio Melo| * Changes for v2.14+fall2025 version.
+| 48          | 10-Nov-2025  | [Apple]Romulo Quidute, [Apple]Antonio Melo| * Changes for v2.14+fall2025 version. +
+| 49          | 14-Nov-2025  | [Apple]Antonio Melo Jr.             | * Adding the Side Load feature instructions to the custom Test Cases section. +
+                                                                     * Fixing the Causeway links in the references section. +
+                                                                     * Using the TH version variable in the Test-Harness Links table. +
+                                                                     * Fixing the REPL command in the Matter Python REPL section.
 |===
 
 <<<
@@ -153,11 +157,11 @@ The TH tool can be used by any DUT vendor to run the Matter certification tests,
 
 <<<
 == *References*
-. Matter Specification: https://groups.csa-iot.org/wg/members-all/document/folder/4651[Matter Specification (Causeway)] / https://github.com/CHIP-Specifications/connectedhomeip-spec[Matter Specification (GitHub)]
+. Matter Specification: https://groups.csa-iot.org/wg/members-all/document/folder/4825[Matter Specification (Causeway)] / https://github.com/CHIP-Specifications/connectedhomeip-spec[Matter Specification (GitHub)]
 . Matter SDK GitHub Repository: https://github.com/project-chip/connectedhomeip[Connectedhomeip GitHub Repository]
-. Matter Test Plans: https://groups.csa-iot.org/wg/members-all/document/folder/4651[Matter Test Plans (Causeway)] / https://github.com/CHIP-Specifications/chip-test-plans[Matter Test Plans (GitHub)]
+. Matter Test Plans: https://groups.csa-iot.org/wg/members-all/document/folder/4825[Matter Test Plans (Causeway)] / https://github.com/CHIP-Specifications/chip-test-plans[Matter Test Plans (GitHub)]
 . Matter PICS Tool: https://picstool.csa-iot.org/#userguide[PICS Tool - Connectivity Standards Alliance (csa-iot.org)]
-. Matter XML Files: https://groups.csa-iot.org/wg/members-all/document/folder/4651[XML Files - Connectivity Standards Alliance (csa-iot.org)]
+. Matter XML Files: https://groups.csa-iot.org/wg/members-all/document/folder/4825[XML Files - Connectivity Standards Alliance (csa-iot.org)]
 . TEDS Matter Tool: https://groups.csa-iot.org/wg/matter-wg/document/28545[TEDS Matter Tool - Connectivity Standards Alliance (csa-iot.org)]
 
 
@@ -455,9 +459,22 @@ Custom Python files folder are located at:
 .Test-Harness displaying the custom tests.
 image::images/img_60.png[]
 
-|===
-|Hint: You can copy the original SDK Yaml/Python test to Custom Yaml/Python folder and do any changes on it.
-|===
+[NOTE]
+.*Experimenting with Test Cases:*
+====
+You can copy the original SDK Yaml/Python test to Custom Yaml/Python folder and do any changes on it.
+====
+
+==== Test-Harness Side Load Feature with Custom Test Cases
+For the Side Load feature, the user may benefit from the *custom* Test Cases feature mentioned above.
+To Side Load any desired script, follow the steps below:
+
+1. Stop the Test-Harness by executing the script `stop.sh` located at `certification-tool/scripts/` folder
+2. Download the latest Test Case script from the SDK's master branch (https://github.com/project-chip/connectedhomeip[connectedhomeip] repository)
+3. Place the desired script on the appropriate *custom* folder (depending if the script is Yaml or Python)
+4. Start the Test-Harness by executing the script `start.sh` located at `certification-tool/scripts/` folder
+5. Change the Project's configuration as required to run the Side Loaded script
+6. The Side Loaded script will be available on the Test Cases list in the Custom tab (refer to the image above)
 
 === Troubleshooting
 
@@ -795,9 +812,9 @@ Remember to set `PATH_TO_PAA_ROOTS` and substitute `<SDK SHA RECOMMENDED>`
 |`source python_env/bin/activate`
 |===
 
-* Run chip-repl:
+* Run matter-repl:
 |===
-|`python3 python_env/bin/chip-repl`
+|`python3 python_env/bin/matter-repl`
 |===
 
 

--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -473,7 +473,7 @@ To Side Load any desired script, follow the steps below:
 2. Download the latest Test Case script from the SDK's master branch (https://github.com/project-chip/connectedhomeip[connectedhomeip] repository)
 3. Place the desired script on the appropriate *custom* folder (depending if the script is Yaml or Python)
 4. Start the Test-Harness by executing the script `start.sh` located at `certification-tool/scripts/` folder
-5. Change the Project's configuration as required to run the Side Loaded script
+5. Change the Project's configuration as required to run the Side Loaded script (e.g. updating `test_parameters`)
 6. The Side Loaded script will be available on the Test Cases list in the Custom tab (refer to the image above)
 
 === Troubleshooting


### PR DESCRIPTION
Updating the user guide for Matter 1.6 TE1 (TH v2.15-beta1+winter2025).

> [!NOTE]
> Pulling the changes to sync with the Matter 1.5 final version update in the [PR#798](https://github.com/project-chip/certification-tool/pull/798)

The following changes were made here:
- Added Side Load feature sub-section for the  Customized Test Scripts section.
- Fixing the Causeway links in the References section
- Using the TH version variable in the Test-Harness Links table
- Fixing the REPL command in the Matter Python REPL section