### PR TITLE
Updated traefik to 3_6_1 and undo workaround to avoid installing Docker 29.* version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,10 +39,11 @@ services:
       - --providers.docker.exposedbydefault=false
       # Enable file provider for push-av server
       - --providers.file.filename=/etc/traefik/traefik_dynamic.yml
-      # insecureSkipVerify is enabled for push_av_server as it uses a self-signed certificate.
-      # This ensures Traefik can proxy requests HTTP -> HTTPS without failing certificate validation.
-      # service specific transport is not supported in v2.2 and was introduced in v2.4 hence enabling it here.
-      - --serversTransport.insecureSkipVerify=true
+      # insecureSkipVerify is now configured per-service in traefik_dynamic.yml
+      # using serversTransports for push_av_server which uses a self-signed certificate
+      # Define entrypoints
+      - --entrypoints.web.address=:80
+      - --entrypoints.traefik.address=:8080
       # Enable the access log, with HTTP requests
       - --accesslog
       # Enable the Traefik log, for configurations and errors

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@
 services:
 
   proxy:
-    image: traefik:v2.2
+    image: traefik:v3.6.1
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:

--- a/scripts/ubuntu/1-install-dependencies.sh
+++ b/scripts/ubuntu/1-install-dependencies.sh
@@ -40,7 +40,7 @@ SAVEIFS=$IFS
 IFS=$(echo -en "\r")
 for package in ${packagelist[@]}; do
   print_script_step "Installing package: ${package[@]}"
-  sudo DEBIAN_FRONTEND=noninteractive apt-get satisfy ${package[@]} -y --allow-downgrades
+  sudo DEBIAN_FRONTEND=noninteractive apt-get satisfy "${package%%[[:space:]]}" -y --allow-downgrades
 done
 IFS=$SAVEIFS 
 

--- a/scripts/ubuntu/1-install-dependencies.sh
+++ b/scripts/ubuntu/1-install-dependencies.sh
@@ -40,22 +40,7 @@ SAVEIFS=$IFS
 IFS=$(echo -en "\r")
 for package in ${packagelist[@]}; do
   print_script_step "Installing package: ${package[@]}"
-
-  # Special handling for docker-ce to avoid version 29.x
-  if [[ "${package%%[[:space:]]}" == docker-ce* ]]; then
-    # Get the latest version that is not 29.x
-    DOCKER_VERSION=$(apt-cache madison docker-ce | awk '$3 !~ /^5:29\./ {print $3; exit}')
-    if [ -n "$DOCKER_VERSION" ]; then
-      print_script_step "Installing docker-ce version $DOCKER_VERSION (excluding 29.x)"
-      sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades docker-ce=$DOCKER_VERSION docker-ce-cli=$DOCKER_VERSION containerd.io
-      sudo apt-mark hold docker-ce docker-ce-cli
-    else
-      echo "ERROR: No suitable docker-ce version found (excluding 29.x)"
-      exit 1
-    fi
-  else
-    sudo DEBIAN_FRONTEND=noninteractive apt-get satisfy "${package%%[[:space:]]}" -y --allow-downgrades
-  fi
+  sudo DEBIAN_FRONTEND=noninteractive apt-get satisfy ${package[@]} -y --allow-downgrades
 done
 IFS=$SAVEIFS 
 

--- a/scripts/ubuntu/package-dependency-list.txt
+++ b/scripts/ubuntu/package-dependency-list.txt
@@ -1,3 +1,3 @@
-docker-ce (>=5:24.0.7-1~ubuntu.22.04~jammy)
+docker-ce (>=5:24.0.7-1~ubuntu.24.04~noble)
 python3-pip (>=24.0+dfsg-1ubuntu1)
 python3-venv (>=3.12.3-0ubuntu1)

--- a/scripts/ubuntu/package-dependency-list.txt
+++ b/scripts/ubuntu/package-dependency-list.txt
@@ -1,3 +1,3 @@
-docker-ce (<< 5:29.0)
+docker-ce (>=5:24.0.7-1~ubuntu.22.04~jammy)
 python3-pip (>=24.0+dfsg-1ubuntu1)
 python3-venv (>=3.12.3-0ubuntu1)

--- a/traefik_dynamic.yml
+++ b/traefik_dynamic.yml
@@ -10,8 +10,12 @@ http:
       loadBalancer:
         servers:
           - url: "https://host.docker.internal:1234"
+        serversTransport: insecure-transport
   middlewares:
     pushav-stripprefix:
       stripPrefix:
         prefixes:
           - "/pushav"
+  serversTransports:
+    insecure-transport:
+      insecureSkipVerify: true


### PR DESCRIPTION
### What changed
The goal of this PR is to update the traefik version and undo changes in https://github.com/project-chip/certification-tool/pull/789 since the new tra traefik version works fine with the latest Docker version (29.*). 

### Related issue
https://github.com/project-chip/certification-tool/issues/792

### Testing
I performed a fresh and update TH installation without any errors.