### PR TITLE
Fix _print_script_step command not found issue

### DIFF
--- a/scripts/ubuntu/auto-update.sh
+++ b/scripts/ubuntu/auto-update.sh
@@ -20,6 +20,8 @@ LOG_FILENAME=$(date +"log-ubuntu-auto-update_%F-%H-%M-%S")
 LOG_PATH="$ROOT_DIR/logs/$LOG_FILENAME"
 SCRIPT_DIR="$ROOT_DIR/scripts"
 
+source "$SCRIPT_DIR/utils.sh"
+
 if [ $# != 1 ] || [ $1 = "--help" ]; then
   echo "Usage:"
   echo "./scripts/ubuntu/auto-update.sh <branch_name>"


### PR DESCRIPTION
### What changed
The goal of this PR is to fix the error message bellow when updating TH.

> ./scripts/ubuntu/auto-update.sh: line 32: print_script_step: command not found

### Related Issue
https://github.com/project-chip/certification-tool/issues/787