### PR TITLE
Fix Docker 29.x compatibility issues with Traefik - v1.5

### DIFF
--- a/scripts/fix-docker-compatibility.sh
+++ b/scripts/fix-docker-compatibility.sh
@@ -16,8 +16,7 @@
 # limitations under the License.
 
 # This script fixes Docker 29.x compatibility issues with Traefik
-# by downgrading to Docker 28.5.2 which is compatible with the current
-# certification tool configuration.
+# by downgrading to the latest compatible Docker 28.x version.
 
 set -e
 

--- a/scripts/fix-docker-compatibility.sh
+++ b/scripts/fix-docker-compatibility.sh
@@ -1,0 +1,121 @@
+#! /usr/bin/env bash
+
+#
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script fixes Docker 29.x compatibility issues with Traefik
+# by downgrading to Docker 28.5.2 which is compatible with the current
+# certification tool configuration.
+
+set -e
+
+ROOT_DIR=$(realpath $(dirname "$0")/..)
+SCRIPT_DIR="$ROOT_DIR/scripts"
+
+source "$SCRIPT_DIR/utils.sh"
+
+print_start_of_script
+
+# Function to get Docker version
+get_docker_version() {
+    if command -v docker >/dev/null 2>&1; then
+        docker --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1
+    else
+        echo "not_installed"
+    fi
+}
+
+# Function to compare version numbers
+version_greater_than() {
+    # Returns 0 (true) if $1 > $2
+    [ "$(printf '%s\n' "$1" "$2" | sort -V | head -n1)" != "$1" ]
+}
+
+print_script_step "Checking current Docker version"
+CURRENT_VERSION=$(get_docker_version)
+
+if [ "$CURRENT_VERSION" = "not_installed" ]; then
+    echo "Docker is not installed. Please install Docker first using the installation scripts."
+    exit 1
+fi
+
+echo "Current Docker version: $CURRENT_VERSION"
+
+# Check if Docker version is 29.x or higher
+if version_greater_than "$CURRENT_VERSION" "28.9.9"; then
+    print_script_step "Docker version $CURRENT_VERSION is >= 29.x, which has compatibility issues with Traefik"
+    print_script_step "Downgrading Docker to a compatible version (latest 28.x)"
+
+    # Remove current Docker installation
+    print_script_step "Removing current Docker installation"
+    sudo apt-get remove -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin || true
+
+    # Ensure Docker repository is available
+    if [ ! -f /etc/apt/sources.list.d/docker.list ]; then
+        echo "Docker repository not found. Setting up Docker repository..."
+        $SCRIPT_DIR/ubuntu/1.1-install-docker-repository.sh
+    fi
+
+    # Update package cache
+    sudo apt-get update -y
+
+    # Install Docker version using the same logic as the working fix
+    print_script_step "Installing Docker (excluding version 29.x)"
+
+    # Get the latest version that is not 29.x (same logic as working fix)
+    DOCKER_VERSION=$(apt-cache madison docker-ce | awk '$3 !~ /^5:29\./ {print $3; exit}')
+
+    if [ -n "$DOCKER_VERSION" ]; then
+        print_script_step "Installing docker-ce version $DOCKER_VERSION (excluding 29.x)"
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades docker-ce=$DOCKER_VERSION docker-ce-cli=$DOCKER_VERSION containerd.io docker-buildx-plugin docker-compose-plugin
+    else
+        echo "ERROR: No suitable docker-ce version found (excluding 29.x)"
+        exit 1
+    fi
+
+    # Hold Docker packages to prevent automatic upgrades
+    print_script_step "Holding Docker packages to prevent automatic upgrades to 29.x"
+    sudo apt-mark hold docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+    # Verify installation
+    NEW_VERSION=$(get_docker_version)
+    echo "New Docker version: $NEW_VERSION"
+
+    if version_greater_than "$NEW_VERSION" "28.9.9"; then
+        echo "WARNING: Docker version is still >= 29.x. You may need to manually downgrade."
+        echo "Current version: $NEW_VERSION"
+        exit 1
+    fi
+
+    print_script_step "Docker successfully downgraded to version $NEW_VERSION"
+
+    # Restart Docker service
+    print_script_step "Restarting Docker service"
+    sudo systemctl restart docker
+
+    # Add current user to docker group if not already added
+    if ! groups $USER | grep &>/dev/null '\bdocker\b'; then
+        print_script_step "Adding user $USER to docker group"
+        sudo usermod -aG docker $USER
+        echo "NOTE: You may need to log out and back in for docker group changes to take effect"
+    fi
+
+    print_script_step "Docker compatibility fix completed successfully"
+
+else
+    echo "Docker version $CURRENT_VERSION is compatible (< 29.x). No action needed."
+fi
+
+print_end_of_script

--- a/scripts/fix-docker-workaround.sh
+++ b/scripts/fix-docker-workaround.sh
@@ -51,7 +51,7 @@ if [ -f "$SCRIPT_DIR/stop.sh" ]; then
     $SCRIPT_DIR/stop.sh
     echo "Services stopped successfully."
 else
-    echo "Warning: stop.sh not found, continuing with Docker fix..."
+    echo "Warning: $SCRIPT_DIR/stop.sh not found, continuing with Docker fix..."
 fi
 
 echo ""
@@ -61,7 +61,7 @@ if [ -f "$SCRIPT_DIR/fix-docker-compatibility.sh" ]; then
     $SCRIPT_DIR/fix-docker-compatibility.sh
     echo "Docker compatibility fix completed."
 else
-    echo "Error: fix-docker-compatibility.sh not found!"
+    echo "Error: $SCRIPT_DIR/fix-docker-compatibility.sh not found!"
     echo "Please ensure the script exists and try again."
     exit 1
 fi
@@ -104,7 +104,7 @@ if [ -f "$SCRIPT_DIR/start.sh" ]; then
     $SCRIPT_DIR/start.sh
     echo "Services started successfully."
 else
-    echo "Warning: start.sh not found. Please start services manually."
+    echo "Warning: $SCRIPT_DIR/start.sh not found. Please start services manually."
     exit 1
 fi
 

--- a/scripts/fix-docker-workaround.sh
+++ b/scripts/fix-docker-workaround.sh
@@ -1,0 +1,119 @@
+#! /usr/bin/env bash
+
+#
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a standalone workaround script to fix Docker 29.x compatibility issues
+# It stops the services, fixes Docker, and restarts the services.
+
+set -e
+
+ROOT_DIR=$(realpath $(dirname "$0")/..)
+SCRIPT_DIR="$ROOT_DIR/scripts"
+
+echo "==================================="
+echo "Docker 29.x Compatibility Fix"
+echo "==================================="
+echo ""
+echo "This script will:"
+echo "1. Stop certification tool services"
+echo "2. Fix Docker compatibility by downgrading from 29.x to 28.x"
+echo "3. Build backend and frontend Docker images"
+echo "4. Restart certification tool services"
+echo ""
+echo "WARNING: This will temporarily stop all running services."
+echo ""
+
+# Ask for confirmation
+read -p "Do you want to continue? (y/N): " -n 1 -r
+echo ""
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Operation cancelled."
+    exit 0
+fi
+
+echo ""
+echo "Step 1/4: Stopping certification tool services..."
+echo "=============================================="
+if [ -f "$SCRIPT_DIR/stop.sh" ]; then
+    $SCRIPT_DIR/stop.sh
+    echo "Services stopped successfully."
+else
+    echo "Warning: stop.sh not found, continuing with Docker fix..."
+fi
+
+echo ""
+echo "Step 2/4: Fixing Docker compatibility..."
+echo "======================================="
+if [ -f "$SCRIPT_DIR/fix-docker-compatibility.sh" ]; then
+    $SCRIPT_DIR/fix-docker-compatibility.sh
+    echo "Docker compatibility fix completed."
+else
+    echo "Error: fix-docker-compatibility.sh not found!"
+    echo "Please ensure the script exists and try again."
+    exit 1
+fi
+
+echo ""
+echo "Step 3/4: Building backend and frontend Docker images..."
+echo "=================================================="
+
+echo "Building backend image..."
+if [ -f "$ROOT_DIR/backend/scripts/build-docker-image.sh" ]; then
+    cd "$ROOT_DIR"
+    ./backend/scripts/build-docker-image.sh
+    echo "Backend image built successfully."
+else
+    echo "Warning: $ROOT_DIR/backend/scripts/build-docker-image.sh not found."
+fi
+
+echo "Building frontend image..."
+if [ -f "$ROOT_DIR/frontend/scripts/build-docker-image.sh" ]; then
+    cd "$ROOT_DIR"
+    ./frontend/scripts/build-docker-image.sh
+    echo "Frontend image built successfully."
+else
+    echo "Warning: $ROOT_DIR/frontend/scripts/build-docker-image.sh not found."
+fi
+
+echo "Pulling chip-cert-bins Docker image..."
+if [ -f "$ROOT_DIR/backend/test_collections/matter/scripts/update-sample-apps.sh" ]; then
+    cd "$ROOT_DIR"
+    ./backend/test_collections/matter/scripts/update-sample-apps.sh
+    echo "Chip-cert-bins image updated successfully."
+else
+    echo "Warning: $ROOT_DIR/backend/test_collections/matter/scripts/update-sample-apps.sh not found."
+fi
+
+echo ""
+echo "Step 4/4: Starting certification tool services..."
+echo "=============================================="
+if [ -f "$SCRIPT_DIR/start.sh" ]; then
+    $SCRIPT_DIR/start.sh
+    echo "Services started successfully."
+else
+    echo "Warning: start.sh not found. Please start services manually."
+    exit 1
+fi
+
+echo ""
+echo "==================================="
+echo "Docker compatibility fix completed!"
+echo "==================================="
+echo ""
+echo "Your certification tool should now be running with a compatible Docker version."
+echo "You can verify the fix by checking that there are no more API version errors in:"
+echo "  docker logs certification-tool-proxy-1"
+echo ""

--- a/scripts/ubuntu/1-install-dependencies.sh
+++ b/scripts/ubuntu/1-install-dependencies.sh
@@ -47,8 +47,8 @@ for package in ${packagelist[@]}; do
     DOCKER_VERSION=$(apt-cache madison docker-ce | awk '$3 !~ /^5:29\./ {print $3; exit}')
     if [ -n "$DOCKER_VERSION" ]; then
       print_script_step "Installing docker-ce version $DOCKER_VERSION (excluding 29.x)"
-      sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades docker-ce=$DOCKER_VERSION docker-ce-cli=$DOCKER_VERSION containerd.io
-      sudo apt-mark hold docker-ce docker-ce-cli
+      sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades docker-ce=$DOCKER_VERSION docker-ce-cli=$DOCKER_VERSION containerd.io docker-buildx-plugin docker-compose-plugin
+      sudo apt-mark hold docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
     else
       echo "ERROR: No suitable docker-ce version found (excluding 29.x)"
       exit 1

--- a/scripts/ubuntu/internal-auto-update.sh
+++ b/scripts/ubuntu/internal-auto-update.sh
@@ -28,6 +28,10 @@ verify_return_code
 print_script_step "Stopping Containers"
 $SCRIPT_DIR/stop.sh
 
+print_script_step "Check and fix Docker compatibility"
+$SCRIPT_DIR/fix-docker-compatibility.sh
+verify_return_code
+
 BRANCH_NAME=$1
 
 print_script_step "Update Test Harness Setup"


### PR DESCRIPTION
### What Changed
Fixes Docker 29.x compatibility issues that cause Traefik proxy failures with "client version 1.24 is too old" errors. Implements automatic Docker version management to prevent compatibility issues during installation and updates.

Changes

-   Fresh Installation Flow Updates:
    - Modified scripts/ubuntu/1-install-dependencies.sh to detect and exclude Docker 29.x versions during fresh installations
    - Added special handling for docker-ce packages to automatically install the latest Docker 28.x version
    - Implemented package holding to prevent automatic upgrades to incompatible versions

-   Update Flow Integration:
    - Updated scripts/ubuntu/internal-auto-update.sh to include Docker compatibility check during system updates
    - Added call to fix-docker-compatibility.sh after stopping containers but before updating

- New Docker Fix Scripts (Workaround):
    - Created scripts/fix-docker-compatibility.sh: Core utility to detect Docker 29.x and downgrade to compatible 28.x versions
    - Created scripts/fix-docker-workaround.sh: Complete standalone solution that stops services, fixes Docker, rebuilds images, and restarts services

### Related Issue
https://github.com/project-chip/certification-tool/issues/812

### Testing
  The following scenarios were covered in this PR:
  - Fresh install for v1.4.2 version, then update TH to v1.5 by running the  following commands:
  git checkout workaround_docker_traefik_issue_v_1_5
  git pull
  `./scripts/ubuntu/auto-update.sh workaround_docker_traefik_issue_v_1_5`

and after updating the issue was not there.

  - Fresh using `workaround_docker_traefik_issue_v_1_5` branch and issue was not there
  
DO NOT MERGE SINCE IT'S STILL WAITING FOR THE CCB