### PR TITLE
[Feature]: Add workflow to build and publish Docker images automatically

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,0 +1,91 @@
+name: Build Docker Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch_or_tag:
+        required: true
+  push:
+    tags:
+      - v*
+
+jobs:
+  build-images:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository when push
+        if: github.event_name == 'push'
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Checkout repository when input
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.target_branch_or_tag }}
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Log in to Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get submodules commit IDs
+        id: submodules
+        run: |
+          echo "backend_sha=$(cd backend && git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+          echo "frontend_sha=$(cd frontend && git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Extract metadata for backend
+        id: meta-backend
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}/csa-certification-tool-backend
+          tags: |
+            type=raw,value=${{ steps.submodules.outputs.backend_sha }}
+
+      - name: Extract metadata for frontend
+        id: meta-frontend
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}/csa-certification-tool-frontend
+          tags: |
+            type=raw,value=${{ steps.submodules.outputs.frontend_sha }}
+      
+      - name: Print tags
+        run: |
+            echo "${{ steps.meta-backend.outputs.tags }}"
+            echo "${{ steps.meta-frontend.outputs.tags }}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64, linux/arm64
+      
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          push: true
+          tags: ${{ steps.meta-backend.outputs.tags }}
+      
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          push: true
+          tags: ${{ steps.meta-frontend.outputs.tags }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automatically build and publish Docker images for the backend and frontend to GHCR.

Previously, users had to build Docker images locally when deploying the certification tool (especially on Raspberry Pi), which can be time-consuming and resource-intensive. This workflow solves that problem by providing pre-built images.

The workflow supports two trigger methods:
- **Push a tag with `v` prefix** (e.g., `v2.14+fall2025-tag`) - builds automatically
- **Manual trigger** via workflow_dispatch - you can specify any branch or tag name

I've tested both trigger methods and verified that images are successfully built and pushed to GHCR.