### PR TITLE
Fix installation failure for GStreamer development packages on Ubuntu 24.04

### DIFF
--- a/scripts/ubuntu/1.2-install-additional-dependencies.sh
+++ b/scripts/ubuntu/1.2-install-additional-dependencies.sh
@@ -29,7 +29,7 @@ print_script_step "Install additional dependencies"
 # First, ensure all dev packages are up to date to match installed library versions
 print_script_step "Updating development packages to match installed library versions"
 sudo DEBIAN_FRONTEND=noninteractive apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install --only-upgrade -y libmount-dev libzstd-dev libblkid-dev 2>/dev/null || true
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --only-upgrade -y libmount-dev libzstd-dev libblkid-dev || true
 
 readarray -t packagelist < "$UBUNTU_SCRIPT_DIR/additional-dependency-list.txt"
 

--- a/scripts/ubuntu/1.2-install-additional-dependencies.sh
+++ b/scripts/ubuntu/1.2-install-additional-dependencies.sh
@@ -26,6 +26,11 @@ print_start_of_script
 
 print_script_step "Install additional dependencies"
 
+# First, ensure all dev packages are up to date to match installed library versions
+print_script_step "Updating development packages to match installed library versions"
+sudo DEBIAN_FRONTEND=noninteractive apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --only-upgrade -y libmount-dev libzstd-dev libblkid-dev 2>/dev/null || true
+
 readarray -t packagelist < "$UBUNTU_SCRIPT_DIR/additional-dependency-list.txt"
 
 for package in "${packagelist[@]}"; do


### PR DESCRIPTION
  ### What changed
Fix installation failure for GStreamer development packages on Ubuntu 24.04 systems that have received security updates, preventing the "unmet dependencies" error during Test Harness installation.
  
Added a pre-installation step that upgrades development packages before attempting to install GStreamer dependencies:
    
Motivation

  Root Cause: Ubuntu 24.04 systems experience a timing window issue where:
  1. Security updates upgrade base libraries (libmount1, libzstd1) to newer versions (e.g., 2.39.3-9ubuntu6.3)
  2. Corresponding development packages (libmount-dev, libzstd-dev) in the repositories still depend on exact old versions (e.g., 2.39.3-9ubuntu6)
  3. When apt-get satisfy "libgstreamer1.0-dev" runs, it fails with "unmet dependencies" errors

  Error example:
  The following packages have unmet dependencies:
   libmount-dev : Depends: libmount1 (= 2.39.3-9ubuntu6) but 2.39.3-9ubuntu6.3 is to be installed
   libzstd-dev : Depends: libzstd1 (= 1.5.5+dfsg2-2build1) but 1.5.5+dfsg2-2build1.1 is to be installed

  This issue occurs on:
  - Systems with pre-existing installations that received security updates
  - Fresh installations during the timing window between base library and dev package updates
  - Different Ubuntu mirrors with varying package synchronization states
  
  ### Related Issue
  https://github.com/project-chip/certification-tool/issues/834
  
  ### Testing
  A fresh installation was performed successfully 