### PR TITLE
Fix OTA image folder in matter User Guide

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -1525,7 +1525,7 @@ ATLs should follow these steps when preparing for OTA-related test cases:
 
 . Generate the OTA image using the Matter `ota_image_tool` with the updated Software Version.
 
-. Provide/Copy the generated `ota-requestor-app.ota` image to the Test Harness `apps/images` directory.
+. Provide/Copy the generated `ota-requestor-app.ota` image to the Test Harness `apps` directory.
 
 . Execute OTA-related test cases using the Test Harness.
 


### PR DESCRIPTION
This PR fixes the target folder for OTA image


Related Issue: https://github.com/project-chip/certification-tool/issues/855