### PR TITLE
Fix intermittent installation failures

### DIFF
--- a/scripts/ubuntu/1.2-install-additional-dependencies.sh
+++ b/scripts/ubuntu/1.2-install-additional-dependencies.sh
@@ -38,7 +38,7 @@ UBUNTU_CODENAME=$(lsb_release -cs)
 SOURCES_FILE="/etc/apt/sources.list.d/ubuntu.sources"
 if [ -f "$SOURCES_FILE" ] && grep -q "^Suites:" "$SOURCES_FILE"; then
     if ! grep -q "${UBUNTU_CODENAME}-updates" "$SOURCES_FILE"; then
-        sudo sed -i -E "/^Suites:.*\b(${UBUNTU_CODENAME}|${UBUNTU_CODENAME}-security)\b/ s/$/ ${UBUNTU_CODENAME}-updates/" "$SOURCES_FILE"
+        sudo sed -i -E "/^Suites:.*\b${UBUNTU_CODENAME}\b([^-]|$)/ s/$/ ${UBUNTU_CODENAME}-updates/" "$SOURCES_FILE"
     fi
 fi
 sudo DEBIAN_FRONTEND=noninteractive apt-get update || \

--- a/scripts/ubuntu/1.2-install-additional-dependencies.sh
+++ b/scripts/ubuntu/1.2-install-additional-dependencies.sh
@@ -26,10 +26,37 @@ print_start_of_script
 
 print_script_step "Install additional dependencies"
 
-# First, ensure all dev packages are up to date to match installed library versions
+# Ensure <codename>-updates is present in apt sources.
+# On minimal Ubuntu images (e.g. Raspberry Pi), the sources file may only contain
+# <codename> and <codename>-security.  Security point releases update runtime libraries
+# (libmount1, zlib1g, libpcre2-8-0, etc.) to patch versions (e.g. -9ubuntu6.4), but the
+# matching -dev packages that accept those versions only exist in <codename>-updates.
+# Without this repo, apt-get satisfy fails with "held broken packages" when resolving
+# transitive -dev dependencies for libgstreamer1.0-dev.
+print_script_step "Ensuring <codename>-updates apt repository is configured"
+UBUNTU_CODENAME=$(lsb_release -cs)
+SOURCES_FILE="/etc/apt/sources.list.d/ubuntu.sources"
+if [ -f "$SOURCES_FILE" ] && grep -q "^Suites:" "$SOURCES_FILE"; then
+    if ! grep -q "${UBUNTU_CODENAME}-updates" "$SOURCES_FILE"; then
+        sudo sed -i "/^Suites:.*${UBUNTU_CODENAME}\([^-]\|$\)/ s/$/ ${UBUNTU_CODENAME}-updates/" "$SOURCES_FILE"
+    fi
+fi
+sudo DEBIAN_FRONTEND=noninteractive apt-get update || true
+
+# First, ensure all dev packages are up to date to match installed library versions.
+# apt-get upgrade in the previous step may update runtime libraries (libmount1, libzstd1,
+# libpcre2-8-0, libselinux1, zlib1g) to security-patch point releases (e.g. -9ubuntu6.4)
+# while their -dev counterparts remain at the pre-upgrade version. This cau ses
+# "held broken packages" errors when apt-get satisfy tries to install libgstreamer1.0-dev
+# and its transitive -dev dependencies (which carry strict = version constraints).
+# Upgrading all affected -dev packages first realigns them with the runtime libraries.
 print_script_step "Updating development packages to match installed library versions"
-sudo DEBIAN_FRONTEND=noninteractive apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install --only-upgrade -y libmount-dev libzstd-dev libblkid-dev || true
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --only-upgrade -y \
+    libmount-dev libblkid-dev \
+    libzstd-dev \
+    libpcre2-dev \
+    libselinux1-dev \
+    zlib1g-dev || true
 
 readarray -t packagelist < "$UBUNTU_SCRIPT_DIR/additional-dependency-list.txt"
 

--- a/scripts/ubuntu/1.2-install-additional-dependencies.sh
+++ b/scripts/ubuntu/1.2-install-additional-dependencies.sh
@@ -38,15 +38,16 @@ UBUNTU_CODENAME=$(lsb_release -cs)
 SOURCES_FILE="/etc/apt/sources.list.d/ubuntu.sources"
 if [ -f "$SOURCES_FILE" ] && grep -q "^Suites:" "$SOURCES_FILE"; then
     if ! grep -q "${UBUNTU_CODENAME}-updates" "$SOURCES_FILE"; then
-        sudo sed -i "/^Suites:.*${UBUNTU_CODENAME}\([^-]\|$\)/ s/$/ ${UBUNTU_CODENAME}-updates/" "$SOURCES_FILE"
+        sudo sed -i -E "/^Suites:.*\b(${UBUNTU_CODENAME}|${UBUNTU_CODENAME}-security)\b/ s/$/ ${UBUNTU_CODENAME}-updates/" "$SOURCES_FILE"
     fi
 fi
-sudo DEBIAN_FRONTEND=noninteractive apt-get update || true
+sudo DEBIAN_FRONTEND=noninteractive apt-get update || \
+    echo "Warning: apt-get update encountered errors, proceeding with existing package index"
 
 # First, ensure all dev packages are up to date to match installed library versions.
 # apt-get upgrade in the previous step may update runtime libraries (libmount1, libzstd1,
 # libpcre2-8-0, libselinux1, zlib1g) to security-patch point releases (e.g. -9ubuntu6.4)
-# while their -dev counterparts remain at the pre-upgrade version. This cau ses
+# while their -dev counterparts remain at the pre-upgrade version. This causes
 # "held broken packages" errors when apt-get satisfy tries to install libgstreamer1.0-dev
 # and its transitive -dev dependencies (which carry strict = version constraints).
 # Upgrading all affected -dev packages first realigns them with the runtime libraries.


### PR DESCRIPTION
### Description 
  Fixes intermittent installation failures on Ubuntu 24.04 (Raspberry Pi / ARM) . The goal is to propagate the fix from  [PR](https://github.com/project-chip/certification-tool/pull/915) targeting targeting v2.14+fall2025 / Matter v1.5) to current and future versions.

### Related Issue
- Github issue [#876](https://github.com/project-chip/certification-tool/issues/876)

### Testing
Fresh installation using `fix/876_fix_matter_v1_5_intermittent_installation_failures` was successfully 