### PR TITLE
Updated User guide - Test Logging Configuration section

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -52,7 +52,7 @@ endif::[]
 | Matter 1.4.1     | v2.12+spring2025   | N/A                                                                                         | https://groups.csa-iot.org/wg/members-all/document/folder/4497[Causeway Link] | 91eab26      | To install, use the tag "v2.12+spring2025" in the instructions of <<fresh_install>>
 | Matter 1.4.2     | v2.13+summer2025   | N/A                                                                                         | https://groups.csa-iot.org/wg/members-all/document/folder/4651[Causeway Link] | 1b2b3fd      | To install, use the tag "v2.13+summer2025" in the instructions of <<fresh_install>>
 | Matter 1.5       | v2.14+fall2025     | N/A                                                                                         | https://groups.csa-iot.org/wg/members-all/document/folder/4825[Causeway Link] | ca9d111      | To install, use the tag "v2.14+fall2025" in the instructions of <<fresh_install>>
-| Matter 1.5.1     | v2.14.1-beta2+winter2026       | N/A                                                                                         | TBD | 4564cd2      | To install, use the branch "v2.14.1-beta2+winter2026" in the instructions of <<fresh_install>>
+| Matter 1.5.1     | v2.14.1+winter2026       | N/A                                                                                         | TBD | e9ecfc2      | To install, use the branch "v2.14.1+winter2026" in the instructions of <<fresh_install>>
 | Matter 1.6     | {th-version}       | N/A                                                                                         | TBD | 4bf7cfc      | To install, use the branch "{th-version}" in the instructions of <<fresh_install>>
 |===
 
@@ -141,6 +141,8 @@ endif::[]
                                                                      * Added Container Logging Configuration section.
 | 54          | 22-Jan-2026  | [Apple]Romulo Quidute               | * Added OTA Image Build Procedure section with manual workflow for generating OTA requestor images.
 | 55          | 05-Feb-2026  | [Apple]Romulo Quidute               | * Added Thread Pairing Mode section.
+| 56          | 20-Mar-2026  | [Apple]Romulo Quidute               | * Fixed docker container name to use Docker Compose V2 naming convention (hyphen separator). +
+                                                                     * Updated Python Test Logging Configuration section.
 |===
 
 <<<
@@ -427,7 +429,7 @@ To update an existing Yaml test script: (e.g. `Test_TC_ACE_1_1.yaml`)
 
 * Restart TH's backend container:
 |===
-|`$docker restart certification-tool_backend_1`
+|`$docker restart certification-tool-backend-1`
 |===
 
 * Changes will be available on the next execution of the yaml test.
@@ -1999,7 +2001,7 @@ The TH supports two modes for displaying Python test logs:
 * *Real-time logging*: Logs are displayed incrementally as each test step completes
 * *Batch logging (default)*: All logs are displayed at once after test execution completes
 
-To configure the logging mode, set the `ENABLE_REALTIME_PYTHON_TEST_LOGS` environment variable in the `./backend/app/core/config.py` file:
+To configure the logging mode, add or update the `ENABLE_REALTIME_PYTHON_TEST_LOGS` environment variable in the `.env` file located in the *root* of the certification-tool directory (i.e. `certification-tool/.env`). Note: do *not* edit `certification-tool/backend/.env` — that file is not used by the backend container:
 
 [source,shell]
 ----
@@ -2016,7 +2018,7 @@ The TH supports optional logging of container operations for debugging and troub
 * *Container logging disabled (default)*: No container operation logs are displayed
 * *Container logging enabled*: Displays detailed Docker container operations including creation, destruction, and file copy operations
 
-To configure container logging, set the `ENABLE_CONTAINER_LOGS` environment variable in the `./backend/app/core/config.py` file:
+To configure container logging, add or update the `ENABLE_CONTAINER_LOGS` environment variable in the same `certification-tool/.env` file:
 
 [source,shell]
 ----
@@ -2034,10 +2036,10 @@ When enabled, the following container information will be logged:
 * File copy operations between host and container
 * Container execution commands
 
-NOTE: After changing any configuration in `./backend/app/core/config.py`, restart the TH backend container:
+NOTE: After changing any configuration in `./.env`, recreate the TH backend container to apply the new environment variables. Use `docker compose up` instead of `docker restart` — `docker restart` does not re-read the `.env` file:
 [source,shell]
 ----
-docker restart certification-tool_backend_1
+docker compose up -d backend
 ----
 
 <<<


### PR DESCRIPTION
### What changed
Updated User guide - Test Logging Configuration section also fixed docker container name to use Docker Compose V2 naming convention (hyphen separator).

### Related Issue
https://github.com/project-chip/certification-tool/issues/659

### Testing
User guide (PDF file) updated
<img width="807" height="429" alt="Screenshot 2026-03-20 at 12 01 14" src="https://github.com/user-attachments/assets/7fa8ab47-0f3d-4f32-a1bf-9e86a9b2bc62" />
