### PR TITLE
Add CLI requirement for side-loaded test cases (-custom suffix) in Section 4.5

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -497,7 +497,14 @@ To Side Load any desired script, follow the steps below:
 3. Place the desired script on the appropriate *custom* folder (depending if the script is Yaml or Python)
 4. Start the Test-Harness by executing the script `start.sh` located at `certification-tool/scripts/` folder
 5. Change the Project's configuration as required to run the Side Loaded script (e.g. updating `test_parameters`)
-6. The Side Loaded script will be available on the Test Cases list in the Custom tab (refer to the image above)
+6. The Side Loaded script will be available on the Test Cases list in the *Custom tab* (refer to the image above)
+7. When executing side-loaded test cases using the CLI, it is mandatory to append the -custom suffix to the Test  Case ID. This suffix ensures that the Test-Harness correctly identifies and executes the script from the custom directory. Test cases invoked without this suffix will not be recognized as side-loaded and may fail to execute as expected.
+
+Example Command:
+ 
+`th-cli run-tests --tests-list TC-JFADMIN-1_1-custom --project-id <id> -c default_config.json --title <Name of  the test run execution>  -p <pics-file-path>`
+ 
+This requirement applies to all test cases placed in the *custom* YAML or Python directories.
 
 === Troubleshooting
 

--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -147,6 +147,7 @@ endif::[]
 | 57          | 15-Apr-2026  | [GRL]Pradeep G                      | * Added nfc-thread and nfc-wifi pairing mode details under the Project Configuration section. +
                                                                      * Added NFC Device Mode (including NFC-Thread Device Mode and NFC-WiFi Device Mode) within the Project Configuration section.
 | 58          | 15-Apr-2026  | [ST]Olivier Lorente                 | * Added NFC commissioning description.
+| 59          | 29-Apr-2026  | [GRL]Sumith D                       | * Updated Section 4.5.1 to include CLI usage guidance for side-loaded test cases, including the -custom                                                                            suffix.
 |===
 
 <<<

--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -497,14 +497,18 @@ To Side Load any desired script, follow the steps below:
 3. Place the desired script on the appropriate *custom* folder (depending if the script is Yaml or Python)
 4. Start the Test-Harness by executing the script `start.sh` located at `certification-tool/scripts/` folder
 5. Change the Project's configuration as required to run the Side Loaded script (e.g. updating `test_parameters`)
-6. The Side Loaded script will be available on the Test Cases list in the *Custom tab* (refer to the image above)
+6. The Side Loaded script will be available on the Test Cases list in the Custom tab (refer to the image above)
 7. When executing side-loaded test cases using the CLI, it is mandatory to append the -custom suffix to the Test  Case ID. This suffix ensures that the Test-Harness correctly identifies and executes the script from the custom directory. Test cases invoked without this suffix will not be recognized as side-loaded and may fail to execute as expected.
 
-Example Command:
- 
-`th-cli run-tests --tests-list TC-JFADMIN-1_1-custom --project-id <id> -c default_config.json --title <Name of  the test run execution>  -p <pics-file-path>`
- 
++
+[source,xml]
+----
+ Example Command:
+
+  th-cli run-tests --tests-list TC-JFADMIN-1_1-custom --project-id <id> --config my_config.json --title <Name of the test run execution>  --pics-config-folder ./pics_files/
+----
 This requirement applies to all test cases placed in the *custom* YAML or Python directories.
+
 
 === Troubleshooting
 
@@ -1529,6 +1533,7 @@ For the case that the DUT requires a PAA certificate to perform a pairing operat
   "trace_log": true
 }
 ----
+
 
 NOTE: Make sure to include the desired PAA certificates in the default path "*/var/paa-root-certs/*", in the Raspberry-Pi.
 


### PR DESCRIPTION
This PR updates Section 4.5 of the Matter Test Harness User Guide to clarify the execution of side-loaded test cases via CLI.

Related Issue: https://github.com/project-chip/certification-tool/issues/969