### PR TITLE
Added missing dependencies for chip-tool

### DIFF
--- a/scripts/ubuntu/additional-dependency-list.txt
+++ b/scripts/ubuntu/additional-dependency-list.txt
@@ -9,6 +9,6 @@ libavcodec60 (>=7:6.0)
 libavutil58 (>=7:6.0)
 libswresample4 (>=7:6.0)
 libswscale7 (>=7:6.0)
-libevent-2.1-7
-libevent-pthreads-2.1-7
-libpcsclite1
+libevent-2.1-7 | libevent-2.1-7t64                                                                                               
+libevent-pthreads-2.1-7 | libevent-pthreads-2.1-7t64                                                                      
+libpcsclite1 | libpcsclite1t64 

--- a/scripts/ubuntu/additional-dependency-list.txt
+++ b/scripts/ubuntu/additional-dependency-list.txt
@@ -11,4 +11,4 @@ libswresample4 (>=7:6.0)
 libswscale7 (>=7:6.0)
 libevent-2.1-7t64
 libevent-pthreads-2.1-7t64
-+libpcsclite1
+libpcsclite1

--- a/scripts/ubuntu/additional-dependency-list.txt
+++ b/scripts/ubuntu/additional-dependency-list.txt
@@ -9,3 +9,6 @@ libavcodec60 (>=7:6.0)
 libavutil58 (>=7:6.0)
 libswresample4 (>=7:6.0)
 libswscale7 (>=7:6.0)
+libevent-2.1-7
+libevent-pthreads-2.1-7
+libpcsclite1

--- a/scripts/ubuntu/additional-dependency-list.txt
+++ b/scripts/ubuntu/additional-dependency-list.txt
@@ -9,6 +9,6 @@ libavcodec60 (>=7:6.0)
 libavutil58 (>=7:6.0)
 libswresample4 (>=7:6.0)
 libswscale7 (>=7:6.0)
-libevent-2.1-7 | libevent-2.1-7t64                                                                                               
-libevent-pthreads-2.1-7 | libevent-pthreads-2.1-7t64                                                                      
-libpcsclite1 | libpcsclite1t64 
+libevent-2.1-7t64
+libevent-pthreads-2.1-7t64
+libpcsclite1t64

--- a/scripts/ubuntu/additional-dependency-list.txt
+++ b/scripts/ubuntu/additional-dependency-list.txt
@@ -11,4 +11,4 @@ libswresample4 (>=7:6.0)
 libswscale7 (>=7:6.0)
 libevent-2.1-7t64
 libevent-pthreads-2.1-7t64
-libpcsclite1t64
++libpcsclite1


### PR DESCRIPTION
### What changed
Add missing runtime library dependencies (libevent and libpcsclite) to the Ubuntu additional dependency list so that chip-tool and other Matter sample app binaries work correctly after a fresh installation. 
  
### Related Issue
https://github.com/project-chip/certification-tool/issues/950

### Testing
chip-tool command is working
<img width="612" height="96" alt="Screenshot 2026-05-08 at 11 00 21" src="https://github.com/user-attachments/assets/7d47a9d6-e45b-4996-8bc8-ffdd23dd7a29" />
