### PR TITLE
Updated Raspberry Pi prerequisites to specify minimum 8 GB RAM requirement

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -148,6 +148,7 @@ endif::[]
                                                                      * Added NFC Device Mode (including NFC-Thread Device Mode and NFC-WiFi Device Mode) within the Project Configuration section.
 | 58          | 15-Apr-2026  | [ST]Olivier Lorente                 | * Added NFC commissioning description.
 | 59          | 29-Apr-2026  | [GRL]Sumith D                       | * Updated Section 4.5.1 to include CLI usage guidance for side-loaded test cases, including the -custom                                                                            suffix.
+| 60          | 08-May-2026  | [Apple]Romulo Quidute               | * Updated Raspberry Pi prerequisites to specify minimum 8 GB RAM requirement.
 |===
 
 <<<
@@ -250,7 +251,7 @@ NOTE: This instruction applies to the latest version of the Test Harness this do
 
 The following equipment will be required to have a complete TH setup:
 
-* *Raspberry Pi Version (4 or 5) with SD card of minimum 64 GB Memory*
+* *Raspberry Pi Version (4 or 5) with minimum 8 GB RAM and SD card of minimum 64 GB storage*
 
 The TH will be installed on Raspberry PI. The TH contains couple of docker container(s) with all the required dependencies for certification tests execution.
 


### PR DESCRIPTION
  Update the TH User Guide to specify a minimum 8 GB RAM requirement for the Raspberry Pi host, addressing test failures caused by memory exhaustion on 4 GB devices.   
  
#### Changes                                                                                                                                                                                                                                                                           
  - Prerequisites section: Updated the Raspberry Pi hardware requirement from "with SD card of minimum 64 GB Memory" to "with minimum 8 GB 
  RAM and SD card of minimum 64 GB storage" — making RAM and storage requirements explicit and separate.
  - Revision history: Added entry 60 documenting this change.                                                                              
                                                                                                                                           
#### Motivation                                                                              
Issue [#974](https://github.com/project-chip/certification-tool/issues/974) reported that TC-ACE-2.1, TC-ACE-2.2, and TC-ACE-2.4 fail to produce complete log files when run on a Raspberry Pi 5 with 4 GB RAM. 
The tests produce unusually large logs; under memory pressure the process is killed mid-run, leaving truncated log files in ~/run_logs and the Web GUI stuck in "Pending". The same tests complete successfully on 8 GB RAM devices. The previous prerequisites section only mentioned storage — no RAM minimum was specified.

#### Impact
  - Documentation only — no code changes.                                                                                                  
  - Users will now see a clear 8 GB RAM minimum in the prerequisites before installation.