### PR TITLE
Fix intermittent installation failures - Matter v1.6

### DIFF
--- a/scripts/ubuntu/1.2-install-additional-dependencies.sh
+++ b/scripts/ubuntu/1.2-install-additional-dependencies.sh
@@ -26,10 +26,38 @@ print_start_of_script
 
 print_script_step "Install additional dependencies"
 
-# First, ensure all dev packages are up to date to match installed library versions
+# Ensure <codename>-updates is present in apt sources.
+# On minimal Ubuntu images (e.g. Raspberry Pi), the sources file may only contain
+# <codename> and <codename>-security.  Security point releases update runtime libraries
+# (libmount1, zlib1g, libpcre2-8-0, etc.) to patch versions (e.g. -9ubuntu6.4), but the
+# matching -dev packages that accept those versions only exist in <codename>-updates.
+# Without this repo, apt-get satisfy fails with "held broken packages" when resolving
+# transitive -dev dependencies for libgstreamer1.0-dev.
+print_script_step "Ensuring <codename>-updates apt repository is configured"
+UBUNTU_CODENAME=$(lsb_release -cs)
+SOURCES_FILE="/etc/apt/sources.list.d/ubuntu.sources"
+if [ -f "$SOURCES_FILE" ] && grep -q "^Suites:" "$SOURCES_FILE"; then
+    if ! grep -q "${UBUNTU_CODENAME}-updates" "$SOURCES_FILE"; then
+        sudo sed -i -E "/^Suites:.*\b${UBUNTU_CODENAME}\b([^-]|$)/ s/$/ ${UBUNTU_CODENAME}-updates/" "$SOURCES_FILE"
+    fi
+fi
+sudo DEBIAN_FRONTEND=noninteractive apt-get update || \
+    echo "Warning: apt-get update encountered errors, proceeding with existing package index"
+
+# First, ensure all dev packages are up to date to match installed library versions.
+# apt-get upgrade in the previous step may update runtime libraries (libmount1, libzstd1,
+# libpcre2-8-0, libselinux1, zlib1g) to security-patch point releases (e.g. -9ubuntu6.4)
+# while their -dev counterparts remain at the pre-upgrade version. This causes
+# "held broken packages" errors when apt-get satisfy tries to install libgstreamer1.0-dev
+# and its transitive -dev dependencies (which carry strict = version constraints).
+# Upgrading all affected -dev packages first realigns them with the runtime libraries.
 print_script_step "Updating development packages to match installed library versions"
-sudo DEBIAN_FRONTEND=noninteractive apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install --only-upgrade -y libmount-dev libzstd-dev libblkid-dev || true
+sudo DEBIAN_FRONTEND=noninteractive apt-get install --only-upgrade -y \
+    libmount-dev libblkid-dev \
+    libzstd-dev \
+    libpcre2-dev \
+    libselinux1-dev \
+    zlib1g-dev || true
 
 readarray -t packagelist < "$UBUNTU_SCRIPT_DIR/additional-dependency-list.txt"
 

--- a/scripts/ubuntu/1.2-install-additional-dependencies.sh
+++ b/scripts/ubuntu/1.2-install-additional-dependencies.sh
@@ -33,8 +33,8 @@ print_script_step "Install additional dependencies"
 # matching -dev packages that accept those versions only exist in <codename>-updates.
 # Without this repo, apt-get satisfy fails with "held broken packages" when resolving
 # transitive -dev dependencies for libgstreamer1.0-dev.
-print_script_step "Ensuring <codename>-updates apt repository is configured"
 UBUNTU_CODENAME=$(lsb_release -cs)
+print_script_step "Ensuring ${UBUNTU_CODENAME}-updates apt repository is configured"
 SOURCES_FILE="/etc/apt/sources.list.d/ubuntu.sources"
 if [ -f "$SOURCES_FILE" ] && grep -q "^Suites:" "$SOURCES_FILE"; then
     if ! grep -q "${UBUNTU_CODENAME}-updates" "$SOURCES_FILE"; then


### PR DESCRIPTION
### Summary

  Fixes intermittent apt-get satisfy failures during Ubuntu dependency installation, particularly on minimal Ubuntu images such as Raspberry Pi. The failures manifest as "held broken packages" errors when resolving transitive -dev dependencies for libgstreamer1.0-dev.

#### Changes

  scripts/ubuntu/1.2-install-additional-dependencies.sh

  - Added <codename>-updates repository validation: Before running apt-get update, the script now checks whether
  /etc/apt/sources.list.d/ubuntu.sources includes the <codename>-updates suite. If missing, it injects it via sed. The Ubuntu codename is resolved
  dynamically via lsb_release -cs.
  - Softened apt-get update failure handling: Changed from a hard set -e abort to a non-fatal warning, allowing the script to continue with the
  existing package index if apt-get update encounters transient errors.
  - Expanded -dev package upgrade list: Added libpcre2-dev, libselinux1-dev, and zlib1g-dev to the pre-upgrade step alongside the existing
  libmount-dev, libblkid-dev, and libzstd-dev.

#### Motivation
  On minimal Ubuntu images (e.g. Raspberry Pi), the apt sources may only include <codename> and <codename>-security. Security updates push runtime libraries (e.g. libmount1, zlib1g, libpcre2-8-0) to patch versions like -9ubuntu6.4, but the matching -dev packages that satisfy those exact version constraints only exist in <codename>-updates. Without that repository, apt-get satisfy fails with "held broken packages" when resolving the transitive -dev dependencies of libgstreamer1.0-dev. The expanded -dev upgrade list addresses the same root cause for additional libraries that share this runtime/dev version skew pattern.

#### Impact

  - Resolves intermittent installation failures on Raspberry Pi and other minimal Ubuntu setups.
  - No breaking changes — all modifications are additive or defensive.
  - apt-get update errors are now non-fatal; a warning is printed and installation proceeds with the cached index.
  - The ubuntu.sources modification only triggers when the file exists, uses the DEB822 Suites: format, and does not already contain <codename>-updates — safe to run on fully configured systems.
  
  
### Related Issue
https://github.com/project-chip/certification-tool/issues/834

### Testing

Perform a fresh installation with the branch and the installation was successfully. 