### PR TITLE
Document NFC pairing mode behavior: discriminator and setup_code are optional

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -1310,6 +1310,7 @@ Depending on the DUT's network transport, any one of the appropriate pairing mod
 * *'thread-meshcop'* to complete the pairing for the Thread Device using Border Agent (without BLE)
 * *'nfc-thread'* to complete the pairing for the Thread Device using NFC Transport Layer (NTL).
 * *'nfc-wifi'* to complete the pairing for the Wi-Fi Device using NFC Transport Layer (NTL).
+* *'nfc-ethernet'* to complete the pairing for the Ethernet Device using NFC Transport Layer (NTL).
 
 Follow the sections below for the project configuration and test execution.
 
@@ -1478,7 +1479,20 @@ Set *pairing_mode as "nfc-wifi"*. The `discriminator` and `setup_code` fields ar
 }
 ----
 
-.. To validate test cases using *nfc-thread* or *nfc-wifi*, the following parameter must be included in the test parameters, irrespective of the test case-specific arguments:
+.. NFC-Ethernet Device Mode:
+Set *pairing_mode as "nfc-ethernet"*. The `discriminator` and `setup_code` fields are optional — onboarding data is read directly from the NFC tag at runtime and these values are ignored if present.
++
+[source,xml]
+----
+"dut_config": {
+  "pairing_mode": "nfc-ethernet",
+  "chip_timeout": null,
+  "chip_use_paa_certs": false,
+  "trace_log": true
+}
+----
+
+.. To validate test cases using *nfc-thread*, *nfc-wifi*, or *nfc-ethernet*, the following parameter must be included in the test parameters, irrespective of the test case-specific arguments:
 +
 [source,xml]
 ----

--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -150,7 +150,8 @@ endif::[]
 | 59          | 29-Apr-2026  | [GRL]Sumith D                       | * Updated Section 4.5.1 to include CLI usage guidance for side-loaded test cases, including the -custom                                                                            suffix.
 | 60          | 08-May-2026  | [Apple]Romulo Quidute               | * Updated Raspberry Pi prerequisites to specify minimum 8 GB RAM requirement.
 | 61          | 15-May-2026  | [Apple]Romulo Quidute               | * Added grouped log download documentation using CLI.
-| 62          | 20-May-2026  | [Apple]Romulo Quidute               | * Updated NFC Device Mode section to clarify that discriminator and setup_code are optional for nfc-thread and nfc-wifi pairing modes — onboarding data is read from the NFC tag at runtime.
+| 62          | 20-May-2026  | [Apple]Romulo Quidute               | * Updated NFC Device Mode section to clarify that discriminator and setup_code are optional for nfc-thread and nfc-wifi pairing modes — onboarding data is read from the NFC tag at runtime. +
+                                                                     * Added note on qr-code behavior: ignored for commissioning tests under NFC modes, preserved for non-commissioning tests.
 |===
 
 <<<
@@ -1492,6 +1493,12 @@ e.g.,
 }
 ----
 NFC_Reader_index tells the test which NFC reader hardware to use (in case there are multiple NFC Readers), and must be set correctly based on the ATL setup. If there is only one NFC reader, its index is 0.
+
+.. `qr-code` in test parameters:
++
+For *commissioning* test cases under NFC pairing modes, the `qr-code` field in `test_parameters` is automatically ignored — onboarding data comes from the NFC tag, not from a QR code. Including it will not cause an error but it will not be used.
++
+For *non-commissioning* test cases (e.g., `TC_DD_1_5`), `qr-code` is a legitimate test input and must be preserved. It is passed to the test as-is and is not stripped.
 
 
 ==== Thread Pairing Mode (using Border Agent)

--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -150,6 +150,7 @@ endif::[]
 | 59          | 29-Apr-2026  | [GRL]Sumith D                       | * Updated Section 4.5.1 to include CLI usage guidance for side-loaded test cases, including the -custom                                                                            suffix.
 | 60          | 08-May-2026  | [Apple]Romulo Quidute               | * Updated Raspberry Pi prerequisites to specify minimum 8 GB RAM requirement.
 | 61          | 15-May-2026  | [Apple]Romulo Quidute               | * Added grouped log download documentation using CLI.
+| 62          | 20-May-2026  | [Apple]Romulo Quidute               | * Updated NFC Device Mode section to clarify that discriminator and setup_code are optional for nfc-thread and nfc-wifi pairing modes — onboarding data is read from the NFC tag at runtime.
 |===
 
 <<<
@@ -1451,13 +1452,11 @@ WARNING: _OTBR needs to be configured and running. TH will not start any OTBR do
 
 ==== NFC Device Mode
 .. NFC-Thread Device Mode:
-Input the DUT configuration details like discriminator: "3840", setup_code:"20202021", and *pairing_mode as "nfc-thread"*.
+Set *pairing_mode as "nfc-thread"*. The `discriminator` and `setup_code` fields are optional — onboarding data is read directly from the NFC tag at runtime and these values are ignored if present.
 +
 [source,xml]
 ----
 "dut_config": {
-  "discriminator": "3840",
-  "setup_code": "20202021",
   "pairing_mode": "nfc-thread",
   "chip_timeout": null,
   "chip_use_paa_certs": false,
@@ -1466,13 +1465,11 @@ Input the DUT configuration details like discriminator: "3840", setup_code:"2020
 ----
 
 .. NFC-WiFi Device Mode:
-Input the DUT configuration details like discriminator: "3840", setup_code:"20202021", and *pairing_mode as "nfc-wifi"*.
+Set *pairing_mode as "nfc-wifi"*. The `discriminator` and `setup_code` fields are optional — onboarding data is read directly from the NFC tag at runtime and these values are ignored if present.
 +
 [source,xml]
 ----
 "dut_config": {
-  "discriminator": "3840",
-  "setup_code": "20202021",
   "pairing_mode": "nfc-wifi",
   "chip_timeout": null,
   "chip_use_paa_certs": false,


### PR DESCRIPTION
### What changed
 Updates the Matter Test Harness User Guide to document the correct behavior of NFC pairing modes (nfc-wifi, nfc-thread) regarding optional configuration fields and qr-code handling.
 
#### Motivation
The previous documentation showed discriminator and setup_code as required fields for NFC pairing modes and gave no guidance on qr-code handling.
This was misleading: for NFC modes the device onboarding payload is always read from the NFC tag, so neither discriminator/setup_code nor qr-code (in commissioning flows) are used. Users needed clear documentation to configure their projects correctly and understand why certain parameters are silently ignored.

#### Impact
Documentation only. No functional changes. Users configuring NFC pairing modes will now correctly understand which fields are required, which are optional, and how qr-code is handled depending on the test type.
  
### Related Issue
https://github.com/project-chip/certification-tool/issues/992 - backend implementation [PR](https://github.com/project-chip/certification-tool-backend/pull/310)

  