### PR TITLE
[Feature] Add Resource Limits for Container

### DIFF
--- a/default.env
+++ b/default.env
@@ -22,7 +22,7 @@ TRAEFIK_TAG=chip-test-harness.com
 TRAEFIK_PUBLIC_TAG=traefik-public
 
 # Proxy resource limits (uncomment to override the defaults shown)
-# PROXY_CPU_LIMIT=0.25
+# PROXY_CPU_LIMIT=0.2
 # PROXY_MEMORY_LIMIT=128M
 
 # Backend
@@ -34,7 +34,7 @@ SECRET_KEY=790dd0ee330f50075404bdb3870273b03bf17347f3f256328fc38afaad28dd64
 # BACKEND_MEMORY_LIMIT=2000M
 
 # Frontend resource limits (uncomment to override the defaults shown)
-# FRONTEND_CPU_LIMIT=0.75
+# FRONTEND_CPU_LIMIT=0.5
 # FRONTEND_MEMORY_LIMIT=700M
 
 # Postgres
@@ -44,6 +44,6 @@ POSTGRES_PASSWORD=b461a2eee00db1934aa87d74d218a8a35eb9fbba09fd7c3f85dccc067b65d1
 POSTGRES_DB=app
 
 # Postgres resource limits (uncomment to override the defaults shown)
-# DB_CPU_LIMIT=0.5
+# DB_CPU_LIMIT=0.3
 # DB_MEMORY_LIMIT=384M
 

--- a/default.env
+++ b/default.env
@@ -16,17 +16,34 @@
 DOMAIN=localhost
 STACK_NAME=chip-test-harness
 
-# Proxy 
+# Proxy
 TRAEFIK_PUBLIC_NETWORK=traefik-public
 TRAEFIK_TAG=chip-test-harness.com
 TRAEFIK_PUBLIC_TAG=traefik-public
 
+# Proxy resource limits (uncomment to override the defaults shown)
+# PROXY_CPU_LIMIT=0.25
+# PROXY_MEMORY_LIMIT=128M
+
 # Backend
 PROJECT_NAME=CHIP Test Harness
 SECRET_KEY=790dd0ee330f50075404bdb3870273b03bf17347f3f256328fc38afaad28dd64
+
+# Backend resource limits (uncomment to override the defaults shown)
+# BACKEND_CPU_LIMIT=2.5
+# BACKEND_MEMORY_LIMIT=2000M
+
+# Frontend resource limits (uncomment to override the defaults shown)
+# FRONTEND_CPU_LIMIT=0.75
+# FRONTEND_MEMORY_LIMIT=700M
 
 # Postgres
 POSTGRES_SERVER=db
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=b461a2eee00db1934aa87d74d218a8a35eb9fbba09fd7c3f85dccc067b65d11e
 POSTGRES_DB=app
+
+# Postgres resource limits (uncomment to override the defaults shown)
+# DB_CPU_LIMIT=0.5
+# DB_MEMORY_LIMIT=384M
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,6 @@ services:
 
   backend:
     image: 'ghcr.io/project-chip/csa-certification-tool-backend:2ac562d'
-
     ports:
       - "8888:8888"
       - "50000:50000"
@@ -100,6 +99,11 @@ services:
     privileged: true
     build:
       context: ./backend
+    deploy:
+      resources:
+        limits:
+          cpus: '2.5'        # cap at 2.5 cores, leave 1.5 for OS + other services
+          memory: 1500M
     command: bash -c "./prestart.sh; python3 ./app/main.py"
     labels:
       - traefik.enable=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,8 +102,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '2.5'        # cap at 2.5 cores, leave 1.5 for OS + other services
-          memory: 1500M
+          cpus: '${BACKEND_CPU_LIMIT:-2.5}'        # If no environment variables is provided, cap at 2.5 cores
+          memory: '${BACKEND_MEMORY_LIMIT:-2000M}' # If no environment variables is provided, cap at 2.0 GB
     command: bash -c "./prestart.sh; python3 ./app/main.py"
     labels:
       - traefik.enable=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,10 @@ services:
       placement:
         constraints:
           - node.role == manager
+      resources:
+        limits:
+          cpus: '${PROXY_CPU_LIMIT:-0.25}'        # If no environment variables is provided, cap at 0.25 cores
+          memory: '${PROXY_MEMORY_LIMIT:-128M}'   # If no environment variables is provided, cap at 128 MB
 
   db:
     image: postgres:12
@@ -76,6 +80,10 @@ services:
       placement:
         constraints:
           - node.labels.${STACK_NAME?Variable not set}.app-db-data == true
+      resources:
+        limits:
+          cpus: '${DB_CPU_LIMIT:-0.5}'        # If no environment variables is provided, cap at 0.5 cores
+          memory: '${DB_MEMORY_LIMIT:-384M}'  # If no environment variables is provided, cap at 384 MB
 
   backend:
     image: 'ghcr.io/project-chip/csa-certification-tool-backend:16a190f'
@@ -115,6 +123,11 @@ services:
     image: 'ghcr.io/project-chip/csa-certification-tool-frontend:10d1822'
     build:
       context: ./frontend
+    deploy:
+      resources:
+        limits:
+          cpus: '${FRONTEND_CPU_LIMIT:-0.75}'        # If no environment variables is provided, cap at 0.75 cores
+          memory: '${FRONTEND_MEMORY_LIMIT:-700M}'   # If no environment variables is provided, cap at 700 MB
     labels:
       - traefik.enable=true
       - traefik.constraint-label-stack=${TRAEFIK_TAG?Variable not set}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
           - node.role == manager
       resources:
         limits:
-          cpus: '${PROXY_CPU_LIMIT:-0.25}'        # If no environment variables is provided, cap at 0.25 cores
+          cpus: '${PROXY_CPU_LIMIT:-0.2}'        # If no environment variables is provided, cap at 0.2 cores
           memory: '${PROXY_MEMORY_LIMIT:-128M}'   # If no environment variables is provided, cap at 128 MB
 
   db:
@@ -82,7 +82,7 @@ services:
           - node.labels.${STACK_NAME?Variable not set}.app-db-data == true
       resources:
         limits:
-          cpus: '${DB_CPU_LIMIT:-0.5}'        # If no environment variables is provided, cap at 0.5 cores
+          cpus: '${DB_CPU_LIMIT:-0.3}'        # If no environment variables is provided, cap at 0.3 cores
           memory: '${DB_MEMORY_LIMIT:-384M}'  # If no environment variables is provided, cap at 384 MB
 
   backend:
@@ -126,7 +126,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '${FRONTEND_CPU_LIMIT:-0.75}'        # If no environment variables is provided, cap at 0.75 cores
+          cpus: '${FRONTEND_CPU_LIMIT:-0.5}'        # If no environment variables is provided, cap at 0.5 cores
           memory: '${FRONTEND_MEMORY_LIMIT:-700M}'   # If no environment variables is provided, cap at 700 MB
     labels:
       - traefik.enable=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,6 @@ services:
 
   backend:
     image: 'ghcr.io/project-chip/csa-certification-tool-backend:16a190f'
-
     ports:
       - "8888:8888"
       - "50000:50000"
@@ -100,6 +99,11 @@ services:
     privileged: true
     build:
       context: ./backend
+    deploy:
+      resources:
+        limits:
+          cpus: '2.5'        # cap at 2.5 cores, leave 1.5 for OS + other services
+          memory: 1500M
     command: bash -c "./prestart.sh; python3 ./app/main.py"
     labels:
       - traefik.enable=true

--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -170,6 +170,7 @@ endif::[]
 | 72          | 04-Sep-2026  | [Apple]Antonio Melo Jr.             | * Updated Container Logging Configuration section to document the `th_config.enable_container_logs` per-project override (issue #1091).
 | 73          | 10-Sep-2026  | [Google]Andrey Khodyrev             | * Added 'For CNET Tests' section with wpa_supplicant volume mapping instructions for the SDK docker container.
 | 74          | 10-Sep-2026  | [Apple]Romulo Quidute               | * Added Repeat, Export, and Import a Test Run Execution sections to the CLI documentation.
+| 75          | 10-Sep-2026  | [Apple]Antonio Melo Jr.             | * Added the Container Resource Limits Configuration section documenting `BACKEND_CPU_LIMIT`/`BACKEND_MEMORY_LIMIT` and the equivalent frontend/db/proxy variables.
 |===
 
 <<<
@@ -2349,6 +2350,35 @@ NOTE: After changing any configuration in `./.env`, recreate the TH backend cont
 ----
 docker compose up -d backend
 ----
+
+[#container-resource-limits-configuration]
+===== Container Resource Limits Configuration
+The `backend`, `frontend`, `db`, and `proxy` containers each have a CPU/memory ceiling set in `docker-compose.yml`, sized by default to fit a resource-constrained Raspberry Pi.
+
+IMPORTANT: These defaults are *not* auto-scaled to the host's actual hardware — they apply the same way whether the TH is running on a Pi or a much more powerful machine. If you're running on hardware well above the minimum spec, raise these limits (or remove them by setting a very high value) so the TH isn't unnecessarily throttled.
+
+The caps are configured via environment variables in `certification-tool/.env` (see `default.env` for the commented-out defaults):
+
+[source,shell]
+----
+# Backend
+BACKEND_CPU_LIMIT=2.5
+BACKEND_MEMORY_LIMIT=2000M
+
+# Frontend
+FRONTEND_CPU_LIMIT=0.75
+FRONTEND_MEMORY_LIMIT=700M
+
+# Database
+DB_CPU_LIMIT=0.5
+DB_MEMORY_LIMIT=384M
+
+# Proxy
+PROXY_CPU_LIMIT=0.25
+PROXY_MEMORY_LIMIT=128M
+----
+
+Changing these variables requires recreating the affected container(s) — see the note at the end of the <<container-logging-configuration,Container Logging Configuration>> section above for how to do this with `docker compose up`.
 
 [#user-prompt-timeout-configuration]
 ===== User Prompt Timeout Configuration

--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -2366,17 +2366,19 @@ BACKEND_CPU_LIMIT=2.5
 BACKEND_MEMORY_LIMIT=2000M
 
 # Frontend
-FRONTEND_CPU_LIMIT=0.75
+FRONTEND_CPU_LIMIT=0.5
 FRONTEND_MEMORY_LIMIT=700M
 
 # Database
-DB_CPU_LIMIT=0.5
+DB_CPU_LIMIT=0.3
 DB_MEMORY_LIMIT=384M
 
 # Proxy
-PROXY_CPU_LIMIT=0.25
+PROXY_CPU_LIMIT=0.2
 PROXY_MEMORY_LIMIT=128M
 ----
+
+The CPU defaults above sum to 3.5 of the 4 physical cores on a Raspberry Pi 4, leaving 0.5 cores (12.5%) of headroom for the host OS even if every container simultaneously peaks.
 
 Changing these variables requires recreating the affected container(s) — see the note at the end of the <<container-logging-configuration,Container Logging Configuration>> section above for how to do this with `docker compose up`.
 

--- a/docs/Raspberry Pi-Setup.md
+++ b/docs/Raspberry Pi-Setup.md
@@ -82,3 +82,23 @@ The following will document how to setup a Raspberry Pi so it can be used for ce
 8. Wait for 5-10 minutes for the test harness to startup, then access it from a browser
 
     `http://<rpi-ip>`
+
+## Resource Limits
+
+On a resource-constrained Raspberry Pi 4 (4 GB RAM, 4 cores), the `backend`, `frontend`, `db`, and `proxy` containers are each capped with a CPU/memory ceiling in `docker-compose.yml`, sized to fit the 4 GB/4-core minimum spec with headroom left for the OS. These caps are configurable via environment variables in `certification-tool/.env` (see `default.env` for the commented-out defaults):
+
+| Service | CPU env var | Default | Memory env var | Default |
+|---|---|---|---|---|
+| backend | `BACKEND_CPU_LIMIT` | 2.5 | `BACKEND_MEMORY_LIMIT` | 2000M |
+| frontend | `FRONTEND_CPU_LIMIT` | 0.75 | `FRONTEND_MEMORY_LIMIT` | 700M |
+| db | `DB_CPU_LIMIT` | 0.5 | `DB_MEMORY_LIMIT` | 384M |
+| proxy | `PROXY_CPU_LIMIT` | 0.25 | `PROXY_MEMORY_LIMIT` | 128M |
+
+To override a default, add the variable to `certification-tool/.env`, for example:
+
+```shell
+# Lower the backend memory cap to 1500M
+BACKEND_MEMORY_LIMIT=1500M
+```
+
+Changing these variables requires recreating the affected container (`docker compose up -d --force-recreate <service>`) for the new limit to take effect.

--- a/docs/Raspberry Pi-Setup.md
+++ b/docs/Raspberry Pi-Setup.md
@@ -22,7 +22,7 @@ The following will document how to setup a Raspberry Pi so it can be used for ce
 ## Requirements
 
 -   SD card 64 GB or more
--   RaspberryPi 4 or newer with at least 4 GB RAM
+-   RaspberryPi 4 or newer with at least 8 GB RAM
 -   Internet access on Raspberry Pi during setup.
 
 1. Download and flash a micro SD-card with [Ubuntu Server 22.04](https://ubuntu.com/download/raspberry-pi/thank-you?version=22.04.3&architecture=server-arm64+raspi) for Raspberry Pi using [Raspberry Pi imager](https://www.raspberrypi.com/software/)
@@ -85,14 +85,14 @@ The following will document how to setup a Raspberry Pi so it can be used for ce
 
 ## Resource Limits
 
-On a resource-constrained Raspberry Pi 4 (4 GB RAM, 4 cores), the `backend`, `frontend`, `db`, and `proxy` containers are each capped with a CPU/memory ceiling in `docker-compose.yml`, sized to fit the 4 GB/4-core minimum spec with headroom left for the OS. These caps are configurable via environment variables in `certification-tool/.env` (see `default.env` for the commented-out defaults):
+On a resource-constrained Raspberry Pi 4 (8 GB RAM minimum, 4 cores), the `backend`, `frontend`, `db`, and `proxy` containers are each capped with a CPU/memory ceiling in `docker-compose.yml`. The CPU limits sum to 3.5 of the 4 physical cores, leaving 0.5 cores (12.5%) of headroom for the host OS even if every container simultaneously peaks; the memory limits total ~3.2 GB, comfortably within the 8 GB minimum. These caps are configurable via environment variables in `certification-tool/.env` (see `default.env` for the commented-out defaults):
 
 | Service | CPU env var | Default | Memory env var | Default |
 |---|---|---|---|---|
 | backend | `BACKEND_CPU_LIMIT` | 2.5 | `BACKEND_MEMORY_LIMIT` | 2000M |
-| frontend | `FRONTEND_CPU_LIMIT` | 0.75 | `FRONTEND_MEMORY_LIMIT` | 700M |
-| db | `DB_CPU_LIMIT` | 0.5 | `DB_MEMORY_LIMIT` | 384M |
-| proxy | `PROXY_CPU_LIMIT` | 0.25 | `PROXY_MEMORY_LIMIT` | 128M |
+| frontend | `FRONTEND_CPU_LIMIT` | 0.5 | `FRONTEND_MEMORY_LIMIT` | 700M |
+| db | `DB_CPU_LIMIT` | 0.3 | `DB_MEMORY_LIMIT` | 384M |
+| proxy | `PROXY_CPU_LIMIT` | 0.2 | `PROXY_MEMORY_LIMIT` | 128M |
 
 To override a default, add the variable to `certification-tool/.env`, for example:
 


### PR DESCRIPTION
Fix: ??
---

## Description
Add backend resource limits for Raspberry Pi 4 deployment

### Changes

**Backend CPU and memory limits** (`docker-compose.yml`)
Added `deploy.resources.limits` to the backend service:
- `cpus: '2.5'` — caps the backend at 2.5 of the 4 available cores, preventing
  test execution from starving the OS, Docker daemon, and other services during
  heavy SDK test runs.
- `memory: 1500M` — prevents the backend from consuming all available RAM and
  forcing the OS to swap to SD card, which causes severe performance degradation
  on Raspberry Pi 4.