### PR TITLE
[Improve UX] Suppress raw Docker errors when pulling backend/frontend images from GHCR

### DIFF
--- a/scripts/update-docker-images.sh
+++ b/scripts/update-docker-images.sh
@@ -37,18 +37,24 @@ set +e
 
 print_script_step "Downloading backend Docker image"
 newgrp docker << END
-docker compose pull backend
+docker compose pull backend 2>/dev/null
 END
 if [ $? -ne 0 ]; then
     BUILD_BACKEND=true
+    printf "\n  NOTE: Pre-built backend image not found in the registry for this branch/tag.\n"
+    printf "  Pre-built images are not published for all branches and releases.\n"
+    printf "  The image will be built locally instead.\n\n"
 fi
 
 print_script_step "Downloading frontend Docker image"
 newgrp docker << END
-docker compose pull frontend
+docker compose pull frontend 2>/dev/null
 END
 if [ $? -ne 0 ]; then
     BUILD_FRONTEND=true
+    printf "\n  NOTE: Pre-built frontend image not found in the registry for this branch/tag.\n"
+    printf "  Pre-built images are not published for all branches and releases.\n"
+    printf "  The image will be built locally instead.\n\n"
 fi
 set -e
 
@@ -59,12 +65,14 @@ END
 
 # In case of failure, the images will be built locally
 if $BUILD_BACKEND; then
+    print_script_step "Building backend Docker image locally"
 newgrp docker << END
     $ROOT_DIR/backend/scripts/build-docker-image.sh
 END
 fi
 
 if $BUILD_FRONTEND; then
+    print_script_step "Building frontend Docker image locally"
 newgrp docker << END
     $ROOT_DIR/frontend/scripts/build-docker-image.sh
 END

--- a/scripts/update-docker-images.sh
+++ b/scripts/update-docker-images.sh
@@ -36,26 +36,36 @@ BUILD_FRONTEND=false
 set +e
 
 print_script_step "Downloading backend Docker image"
+BACKEND_ERR=$(mktemp)
 newgrp docker << END
-docker compose pull backend 2>/dev/null
+docker compose pull backend 2>$BACKEND_ERR
 END
 if [ $? -ne 0 ]; then
     BUILD_BACKEND=true
-    printf "\n  NOTE: Pre-built backend image not found in the registry for this branch/tag.\n"
-    printf "  Pre-built images are not published for all branches and releases.\n"
-    printf "  The image will be built locally instead.\n\n"
+    if grep -q -E "manifest unknown|not found" "$BACKEND_ERR"; then
+        printf "\n  NOTE: Pre-built backend image not found in the registry for this branch/tag.\n"
+        printf "  The image will be built locally instead.\n\n"
+    else
+        cat "$BACKEND_ERR" >&2
+    fi
 fi
+rm -f "$BACKEND_ERR"
 
 print_script_step "Downloading frontend Docker image"
+FRONTEND_ERR=$(mktemp)
 newgrp docker << END
-docker compose pull frontend 2>/dev/null
+docker compose pull frontend 2>$FRONTEND_ERR
 END
 if [ $? -ne 0 ]; then
     BUILD_FRONTEND=true
-    printf "\n  NOTE: Pre-built frontend image not found in the registry for this branch/tag.\n"
-    printf "  Pre-built images are not published for all branches and releases.\n"
-    printf "  The image will be built locally instead.\n\n"
+    if grep -q -E "manifest unknown|not found" "$FRONTEND_ERR"; then
+        printf "\n  NOTE: Pre-built frontend image not found in the registry for this branch/tag.\n"
+        printf "  The image will be built locally instead.\n\n"
+    else
+        cat "$FRONTEND_ERR" >&2
+    fi
 fi
+rm -f "$FRONTEND_ERR"
 set -e
 
 print_script_step "Downloading proxy and db Docker images"


### PR DESCRIPTION
### What changed
Improves the user experience during installation and updates when pre-built backend or frontend Docker images are not available in the GHCR registry, replacing a confusing raw Docker error with a clear informational message and a visible local build step.

#### Changes

  - scripts/update-docker-images.sh
    - Redirected docker compose pull stderr to /dev/null for both backend and frontend, suppressing the raw Error response from daemon: manifest unknown
  output.
    - Added a user-friendly NOTE: message when a pull fails, explaining that pre-built images are not published for all branches and releases, and that the image will be built locally.
    - Added print_script_step banners before each local build fallback (Building backend Docker image locally / Building frontend Docker image locally) to make progress visible.

#### Motivation
  Users encountered the Docker daemon error manifest unknown during installation on branches/releases that do not have pre-built images published to GHCR (issue #1011). The existing fallback to a local build was already in place but was silent — leaving users confused about whether the process had failed.
  This affects not just development branches but also some release branches where images are not always published.

#### Impact
  - No functional change — the local build fallback behavior is identical.
  - Users will no longer see alarming Docker daemon errors during a normal install/update flow.
  - The install/update output is clearer and easier to follow when a local build is triggered.
  
### Related Issue
#1011 

### Testing
Perform fresh/update installation successfully
<img width="580" height="236" alt="Screenshot 2026-06-01 at 10 22 32" src="https://github.com/user-attachments/assets/9a7ebd8f-7719-48c7-875f-b0850f4fb867" />
