### PR TITLE
Fix example test ID format in side-load CLI example (#1002)

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -508,7 +508,7 @@ To Side Load any desired script, follow the steps below:
 ----
  Example Command:
 
-  th-cli run-tests --tests-list TC-JFADMIN-1_1-custom --project-id <id> --config my_config.json --title <Name of the test run execution>  --pics-config-folder ./pics_files/
+  th-cli run-tests --tests-list TC-JFADMIN-1.1-custom --project-id <id> --config my_config.json --title <Name of the test run execution>  --pics-config-folder ./pics_files/
 ----
 This requirement applies to all test cases placed in the *custom* YAML or Python directories.
 


### PR DESCRIPTION
## Summary
- The side-load example command in the user guide used `TC-JFADMIN-1_1-custom`, but Matter test case IDs conventionally use dots (e.g. `TC-ACE-1.1`), as already shown elsewhere in the same guide.
- Updated the example to `TC-JFADMIN-1.1-custom` so users copying the example get the standard format.

Fixes #1002

## Test plan
- [x] `git diff` shows only the single example line changed in `docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc`
- [ ] Render the AsciiDoc section to confirm the example block still formats correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)