### PR TITLE
Cherry-pick #1052: Enhance user guide with hostname usage in the Quick start guide

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -158,6 +158,7 @@ endif::[]
                                                                      * Modified the specific release url to Matter Specifications and Test Plans(home path)
 | 65          | 15-Jun-2026  | [Apple]Romulo Quidute               | * Added TC Parameters Mapping File (`--tc-params-file` / `-m`) documentation in the CLI section.
 | 66          | 07-Jul-2026  | [Apple]Romulo Quidute               | * Added Download project logs documentation in the CLI section.
+| 67          | 16-Jul-2026  | [GRL]Pradeep G                      | * Added clarification on hostname usage in Quick-Start Guide of CLI section.
 |===
 
 <<<
@@ -2248,6 +2249,15 @@ Edit `~/certification-tool/cli/config.json`:
     "hostname": "192.168.1.100"
 }
 ----
++
+The `hostname` field in `config.json` tells the CLI where to find the Test Harness (TH) backend — it is *not* the address of the DUT.
++
+If `th-cli` is installed on a *separate machine from the TH* (e.g. a laptop connecting to a TH running on a lab Raspberry Pi or server), set `hostname` to the TH host's actual IP address, as shown in the above example (`192.168.1.100`). 
++
+If TH and `th-cli` are running on the *same machine*, since everything is local, this step is not needed - the CLI defaults to `hostname: "localhost"` automatically.
+
++
+NOTE: It is advisable to run TH and `th-cli` on the same machine.
 
 . View available tests:
 +


### PR DESCRIPTION
## Summary
Cherry-picks #1052 onto `v2.16-beta2+summer2026` (Matter v1.7 TE2).

Original PR: #1052
Related Issue: #1047

Adds clarification in the User Guide's Quick-Start section about the `hostname` field in `cli/config.json`:
- It identifies the Test Harness (TH) backend, not the DUT.
- Set it to the TH host's IP when `th-cli` runs on a separate machine.
- Defaults to `localhost` when TH and `th-cli` run on the same machine (recommended).

## Notes
- Cherry-picked cleanly except for a conflict in the doc's revision-history table (row numbering only, since beta2 already has newer entries up to #66). Resolved by adding the new entry as row 67.
- The accompanying PDF (`Matter_TH_User_Guide.pdf`) was **not** regenerated in this cherry-pick (Docker/asciidoctor-pdf unavailable in this environment) — it should be rebuilt via `scripts/generate-pdf-user-guide.sh` before merge to stay in sync with the `.adoc` changes.
