### PR TITLE
Cherry-pick #1059: Document running side-loaded Python scripts inside container

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -159,6 +159,7 @@ endif::[]
 | 65          | 15-Jun-2026  | [Apple]Romulo Quidute               | * Added TC Parameters Mapping File (`--tc-params-file` / `-m`) documentation in the CLI section.
 | 66          | 07-Jul-2026  | [Apple]Romulo Quidute               | * Added Download project logs documentation in the CLI section.
 | 67          | 16-Jul-2026  | [GRL]Pradeep G                      | * Added clarification on hostname usage in Quick-Start Guide of CLI section.
+| 68          | 21-Jul-2026  | [Apple]Romulo Quidute               | * Added instructions for running a side loaded Python script directly inside the container when it depends on shared SDK modules.
 |===
 
 <<<
@@ -520,6 +521,38 @@ To Side Load any desired script, follow the steps below:
   th-cli run-tests --tests-list TC-JFADMIN-1.1-custom --project-id <id> --config my_config.json --title <Name of the test run execution>  --pics-config-folder ./pics_files/
 ----
 This requirement applies to all test cases placed in the *custom* YAML or Python directories.
+
+==== Running a Side Loaded Python Script Directly Inside the Container
+
+A side-loaded Python script placed in the *custom* Python folder
+(`.../sdk_checkout/python_testing/scripts/custom/`) may import shared SDK helper modules
+(e.g. `TC_GC_common.py`, `TC_TLSCERT_Base.py`) that only exist in the sibling *sdk* folder
+(`.../sdk_checkout/python_testing/scripts/sdk/`).
+
+When the Test-Harness executes a side-loaded script through the normal `run-tests` flow
+(CLI or UI), it automatically makes the *sdk* folder's modules available to the script, so
+these imports resolve without any extra steps.
+
+To run the script directly inside the container (e.g. `docker exec` into the backend container
+and invoke it manually for debugging), the *sdk* scripts folder must be added to `PYTHONPATH`
+so those imports can be found:
+
+[source,bash]
+----
+cd /root/python_testing/scripts/custom
+PYTHONPATH=/root/python_testing/scripts/sdk python3 <script_name>.py \
+  --commissioning-method on-network --discriminator <value> --passcode <value> \
+  --storage-path admin_storage.json --endpoint <value>
+----
+
+[NOTE]
+.*ModuleNotFoundError when running without PYTHONPATH:*
+====
+Running the script directly (`python3 <script_name>.py`) from inside the *custom* folder
+without setting `PYTHONPATH` will fail with `ModuleNotFoundError` for any import that only
+exists in the *sdk* folder. This only affects manual invocation inside the container — it
+does not affect test execution through the Test-Harness CLI or UI.
+====
 
 
 === Troubleshooting


### PR DESCRIPTION
## Summary
Cherry-picks #1059 onto `v2.16-beta2+summer2026`.

Original PR: #1059
Related Issue: #1054

Adds a new User Guide subsection under "Test-Harness Side Load Feature with Custom Test Cases" explaining how to manually run a side-loaded Python script directly inside the container when it imports shared SDK helper modules (e.g. `TC_GC_common.py`) that only live in the sibling `sdk/` scripts folder.

The Test-Harness's normal `run-tests` flow (CLI/UI) already makes these imports resolve correctly on its own. Manual invocation inside the container needs `PYTHONPATH` set to the `sdk` scripts folder, otherwise it fails with `ModuleNotFoundError`.

## Notes
- Cherry-picked cleanly except for a conflict in the doc's revision-history table (row numbering only, since beta2 already has newer entries up to #67). Resolved by adding the new entry as row 68.
- The accompanying PDF (`Matter_TH_User_Guide.pdf`) was **not** regenerated in this cherry-pick (Docker/asciidoctor-pdf unavailable in this environment) — it should be rebuilt via `scripts/generate-pdf-user-guide.sh` before merge to stay in sync with the `.adoc` changes.
