### PR TITLE
[FIX] Docker Compose Pull Flag

### DIFF
--- a/scripts/clean-up.sh
+++ b/scripts/clean-up.sh
@@ -24,21 +24,21 @@ source "$SCRIPT_DIR/utils.sh"
 set -e
 
 clean_up_environment() {
-	rm -rf $HOME/apps
-	rm -rf $HOME/.cache/pypoetry
+    rm -rf $HOME/apps
+    rm -rf $HOME/.cache/pypoetry
 
-	print_script_step "Resetting Database"
-	if [ ! $(docker ps -aq -f name=^certification-tool-backend-1$) ]; then
-		docker compose -f $ROOT_DIR/docker-compose.yml -f $ROOT_DIR/docker-compose.override-backend-dev.yml up db backend --detach --no-build --pull never
-	fi
-	docker exec certification-tool-backend-1 bash -c "./prestart.sh ; poetry install ; ./scripts/reset_db.py"
+    print_script_step "Resetting Database"
+    if [ ! $(docker ps -aq -f name=^certification-tool-backend-1$) ]; then
+        docker compose -f "$ROOT_DIR/docker-compose.yml" -f "$ROOT_DIR/docker-compose.override-backend-dev.yml" up db backend --detach --no-build --pull never
+    fi
+    docker exec certification-tool-backend-1 bash -c "./prestart.sh ; poetry install ; ./scripts/reset_db.py"
 
-	print_script_step "Stopping all docker containers"
-	$ROOT_DIR/scripts/stop.sh
+    print_script_step "Stopping all docker containers"
+    $ROOT_DIR/scripts/stop.sh
 
-	print_script_step "Cleaning All Images"
-	docker network prune -f
-	docker system prune -af --volumes
+    print_script_step "Cleaning All Images"
+    docker network prune -f
+    docker system prune -af --volumes
 }
 
 print_start_of_script
@@ -49,10 +49,10 @@ read -p "Are you sure you want to clean up the Test-Harness environment? [y/N] "
 echo
 
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-	clean_up_environment
+    clean_up_environment
 else
-	echo
-	echo "Cancelling..."
+    echo
+    echo "Cancelling..."
 fi
 
 print_end_of_script

--- a/scripts/clean-up.sh
+++ b/scripts/clean-up.sh
@@ -29,7 +29,7 @@ clean_up_environment() {
 
 	print_script_step "Resetting Database"
 	if [ ! $(docker ps -aq -f name=^certification-tool-backend-1$) ]; then
-		docker compose -f $ROOT_DIR/docker-compose.yml -f $ROOT_DIR/docker-compose.override-backend-dev.yml up db backend --detach --no-build
+		docker compose -f $ROOT_DIR/docker-compose.yml -f $ROOT_DIR/docker-compose.override-backend-dev.yml up db backend --detach --no-build --pull never
 	fi
 	docker exec certification-tool-backend-1 bash -c "./prestart.sh ; poetry install ; ./scripts/reset_db.py"
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -74,7 +74,7 @@ done
 set +e
 
 echo "*** Starting 'db' and 'proxy' docker containers"
-docker compose -f docker-compose.yml up db proxy --detach
+docker compose -f docker-compose.yml up db proxy --detach --pull never
 if [ $? -ne 0 ]; then
     echo "### Exit with Error ###"
     echo "    Unable to start containers."
@@ -83,7 +83,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "*** Starting 'backend' docker container"
-docker compose -f docker-compose.yml $BACKEND_COMPOSE up backend --detach --no-build
+docker compose -f docker-compose.yml $BACKEND_COMPOSE up backend --detach --no-build --pull never
 if [ $? -ne 0 ]; then
     echo "### Exit with Error ###"
     echo "    Unable to start backend container."
@@ -93,7 +93,7 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "*** Starting 'frontend' docker container"
-docker compose -f docker-compose.yml $FRONTEND_COMPOSE up frontend --detach --no-build
+docker compose -f docker-compose.yml $FRONTEND_COMPOSE up frontend --detach --no-build --pull never
 if [ $? -ne 0 ]; then
     echo "### Exit with Error ###"
     echo "    Unable to start frontend container."


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/1049
---

## Description

The `docker compose up` defaults to `--pull missing`, which, depending on the Docker Compose version, can still attempt to contact the registry before falling back to a locally cached image. On a host with no path to the registry, that attempt can fail outright instead of silently using the local image, even though the image needed to start the containers is already present on disk.

This was reported in the field on a Raspberry Pi: `auto-install.sh` was run over a WiFi hotspot with internet (pulling all required images), then the device was switched to a wired connection with no internet access. The `start.sh` failed on that subsequent run despite every image it needed already being cached locally.

## Change

Add `--pull never` to the `docker compose up` invocations that start containers from already-pulled images, so Compose is explicitly told to never contact the registry and only use what's cached locally:

- `scripts/start.sh` — all three `up` calls (db/proxy, backend, frontend)
- `scripts/clean-up.sh` — the `up db backend` call used when resetting the database

 ## Testing

Verified on a Raspberry Pi (Ubuntu Server 24.04, Docker 28.5.2, Compose v5.3.1):

- Simulated a fully offline network (iptables `DROP` on all traffic to `ghcr.io`, confirmed via `curl -4 -m5 -sI https://ghcr.io` timing out at the timeout limit) with images already pulled locally.
- With the `--pull never` fix applied, `./scripts/start.sh` starts db, proxy, backend, and frontend successfully with no delay or failure.