### PR TITLE
[Fix] Docker Download Reachability

### DIFF
--- a/scripts/ubuntu/1.1-install-docker-repository.sh
+++ b/scripts/ubuntu/1.1-install-docker-repository.sh
@@ -32,11 +32,14 @@ set +e
 print_script_step "Verify download.docker.com is reachable"
 # Verify download.docker.com is reachable before attempting to install the
 # Docker Package Repo (network randomly fails after service restarts).
+# Port 443 is checked (not 80) since this script only ever talks to this
+# host over HTTPS (see curl/apt source below).
 for i in {1..5}
 do
-    status_code=$(sudo curl -sS -o /dev/null -w "%{http_code}" --connect-timeout 1 "https://download.docker.com" $proxy_opt)
-    if [ $? -eq 0 ] && [ "$status_code" -lt 400 ]; then
-        echo "The download.docker.com is reachable"
+    timeout 2 bash -c "(echo >/dev/tcp/download.docker.com/443) &>/dev/null"
+    retVal=$?
+    if [ $retVal -eq 0 ]; then
+        echo "The download.docker.com is reacheable"
         break
     else
         echo "The download.docker.com is unreachable for try $i"


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/1084
---

### Description
  `scripts/ubuntu/1.1-install-docker-repository.sh` pre-checks network reachability before installing the Docker apt repository, but the check targets `docker.download.com` — a typo introduced when this check was first added (words swapped). The domain the script actually depends on, used a few lines later for the GPG key fetch and apt source, is `download.docker.com`.

`docker.download.com` happens to resolve to an unrelated host, so the check could pass or fail independently of whether Docker's real infrastructure was reachable. On a different network, that host isn't reachable, causing the script to fail before ever attempting the actual installation — even though `download.docker.com` may be fine.

The check also tested TCP port 80, while the script only ever talks to this host over HTTPS (port 443), so the probe didn't reflect real usage.

### Fix
  - Corrected the hostname to `download.docker.com` in the reachability
    check (and log messages).
  - Changed the probed port from 80 to 443 to match how the script
    actually accesses the host.

### Testing
  - Verified `download.docker.com` resolves and is reachable on port 443.
  - Ran the script end-to-end to confirm the Docker repository install
    still succeeds.