### PR TITLE
Release v2.15.1+summer2026 (backend fix for #1087)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
           - node.labels.${STACK_NAME?Variable not set}.app-db-data == true
 
   backend:
-    image: 'ghcr.io/project-chip/csa-certification-tool-backend:a4e50ff'
+    image: 'ghcr.io/project-chip/csa-certification-tool-backend:4cb5753'
 
     ports:
       - "8888:8888"


### PR DESCRIPTION
## Summary

Re-pins `backend` to bring in the fix for backend [#358](https://github.com/project-chip/certification-tool-backend/pull/358), addressing [#1087](https://github.com/project-chip/certification-tool/issues/1087) / [#1089](https://github.com/project-chip/certification-tool/issues/1089): `TC-IDM-10.2`, `TC-IDM-10.3`, `TC-IDM-10.4`, `TC-IDM-10.5`, and `TC-IDM-12.1` were listed under both `Mandatory SDK Python Tests` and `SDK Python Tests` (Old Script Format), causing double execution via the TH CLI.

## Changes

- `backend` submodule: `a4e50ff` → `4cb5753` (tip of `v2.15.1-develop`)
- `docker-compose.yml`: backend image tag `a4e50ff` → `4cb5753`
- `frontend`, `cli`: unchanged (already at their release tips)
- User guide: unchanged (`:th-version:` already `v2.15.1+summer2026`, SDK_SHA unchanged)

## Verification

- `backend`'s `.version_information` at the pinned commit reads `v2.15.1+summer2026`, matching this release.
- Confirmed via `git diff --submodule=short` that only `backend` moves; `frontend`/`cli` pins are untouched.
