### PR TITLE
Update Causeway link for Matter 1.6.1

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -54,7 +54,7 @@ endif::[]
 | Matter 1.5       | v2.14+fall2025     | N/A                                                                                         | https://groups.csa-iot.org/wg/members-all/document/folder/4825[Causeway Link] | ca9d111      | To install, use the tag "v2.14+fall2025" in the instructions of <<fresh_install>>
 | Matter 1.5.1     | v2.14.1+winter2026       | N/A                                                                                         | https://groups.csa-iot.org/wg/members-all/document/folder/5210[Causeway Link] | e9ecfc2      | To install, use the branch "v2.14.1+winter2026" in the instructions of <<fresh_install>>
 | Matter 1.6     | v2.15+spring2026       | N/A                                                                                         | https://groups.csa-iot.org/wg/members-all/document/folder/2269[Causeway Link] | ad9cf71      | To install, use the branch "v2.15+spring2026" in the instructions of <<fresh_install>>
-| Matter 1.6.1   | {th-version}       | N/A                                                                                         | TBD | e91ea83      | To install, use the branch "{th-version}" in the instructions of <<fresh_install>>
+| Matter 1.6.1   | {th-version}       | N/A                                                                                         | https://groups.csa-iot.org/wg/members-all/document/folder/2269[Causeway Link] | e91ea83      | To install, use the branch "{th-version}" in the instructions of <<fresh_install>>
 |===
 
 
@@ -155,6 +155,7 @@ endif::[]
                                                                      * Modified the specific release url to Matter Specifications and Test Plans(home path)
 | 63          | 16-Jul-2026  | [GRL]Pradeep G                      | * Added clarification on hostname usage in Quick-Start Guide of CLI section.
 | 64          | 21-Jul-2026  | [Apple]Romulo Quidute               | * Added instructions for running a side loaded Python script directly inside the container when it depends on shared SDK modules.
+| 65          | 01-Sep-2026  | [GRL]Pradeep G                      | * Updated the all members causeway location url for Matter 1.6.1 (v2.15.1+summer2026) in the Test-Harness Links section.
 |===
 
 <<<


### PR DESCRIPTION
Updated the all members Causeway location URL for Matter 1.6.1 in the Test-Harness Links section.