### PR TITLE
Release v2.15.1+summer2026 (frontend bump)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,7 @@ services:
       - traefik.http.services.${STACK_NAME?Variable not set}-backend.loadbalancer.server.port=80
 
   frontend:
-    image: 'ghcr.io/project-chip/csa-certification-tool-frontend:c3828c8'
+    image: 'ghcr.io/project-chip/csa-certification-tool-frontend:0c39a86'
     build:
       context: ./frontend
     labels:


### PR DESCRIPTION
## Summary
Third release round for `v2.15.1+summer2026`: bumps the `frontend` submodule pin (and matching `docker-compose.yml` image tag) to pick up the latest tip of `main`.

## Changes
- `frontend` submodule: `c3828c8` → `0c39a86` (origin/main tip)
- `docker-compose.yml`: frontend image tag `c3828c8` → `0c39a86`

## Unchanged this round
- `backend` remains pinned at `4cb5753` (already at `origin/v2.15.1-develop` tip; `.version_information` confirms `v2.15.1+summer2026`, `SDK_SHA` unchanged at `e91ea83`)
- `cli` pin unchanged
- Matter TH User Guide: `:th-version:` already `v2.15.1+summer2026`, no stale rows found, no new row needed
