### PR TITLE
[Feature] Adding CLI Project Edit To User Guide

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -2576,6 +2576,19 @@ th-cli project update --id 5 --config updated_config.json
 th-cli project delete --id 5
 ----
 
+**Edit project config interactively:**
+
+[source,bash]
+----
+# Open the project's current config in your local editor and save to persist changes
+th-cli project edit --id 5
+----
+
+Use this to tweak one or two fields (e.g. a `th_config` or `dut_config` value) without exporting, hand-editing, and re-importing a full config file. The editor opens via `$EDITOR`/`$VISUAL` (falling back to `vim`/`nano`/`vi`); on save, the CLI validates your changes, warns before persisting any field it doesn't recognize, and reopens the editor with your edit preserved if something's wrong.
+
+NOTE: *Tip:* +
+For the full behavior — retry handling on invalid input, the new-field confirmation prompt, and how to pick a different editor via `$EDITOR`/`$VISUAL` — run `th-cli project edit --help` or see the https://github.com/project-chip/certification-tool-cli/blob/main/README.md#edit-project[CLI README].
+
 **Download project logs:**
 
 [source,bash]

--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -2587,7 +2587,7 @@ th-cli project edit --id 5
 Use this to tweak one or two fields (e.g. a `th_config` or `dut_config` value) without exporting, hand-editing, and re-importing a full config file. The editor opens via `$EDITOR`/`$VISUAL` (falling back to `vim`/`nano`/`vi`); on save, the CLI validates your changes, warns before persisting any field it doesn't recognize, and reopens the editor with your edit preserved if something's wrong.
 
 NOTE: *Tip:* +
-For the full behavior — retry handling on invalid input, the new-field confirmation prompt, and how to pick a different editor via `$EDITOR`/`$VISUAL` — run `th-cli project edit --help` or see the https://github.com/project-chip/certification-tool-cli/blob/main/README.md#edit-project[CLI README].
+For the full behavior — retry handling on invalid input, the new-field confirmation prompt, and how to pick a different editor via `$VISUAL`/`$EDITOR` — run `th-cli project edit --help` or see the https://github.com/project-chip/certification-tool-cli/blob/main/README.md#edit-project[CLI README].
 
 **Download project logs:**
 


### PR DESCRIPTION
Fix:https://github.com/project-chip/certification-tool/issues/1094
---

## Description

- Adds a short "Edit project config interactively" subsection to the Project Management section of the User Guide, documenting the new th-cli project edit --id <ID> command (added in the certification-tool-cli submodule).
- Keeps the in-doc explanation minimal — what the command does and when to use it — and points readers to th-cli project edit --help or the CLI repo's README for full details (retry behavior on invalid input, the new-field confirmation prompt, choosing an editor via $EDITOR/$VISUAL), rather than duplicating that content here.

## Changes

- docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc: new subsection inserted between the existing "Update and delete" and "Download project logs" blocks under Project Management, matching the existing bold-header + NOTE: *Tip:* style used elsewhere in that section.