### PR TITLE
Fix wrong step-id reference blanking frontend image tag in build-docker-images.yml

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -107,7 +107,7 @@ jobs:
 
         - name: Ensure frontend sha is used in docker-compose
           env:
-            SHORT_HASH: ${{ steps.frontend.outputs.tag }}
+            SHORT_HASH: ${{ steps.frontend_tag.outputs.tag }}
           run:
             sed -i "s/frontend:[a-z0-9]\{7\}/frontend:${SHORT_HASH}/" docker-compose.yml
 


### PR DESCRIPTION
## Summary

Fixes #1102.

`.github/workflows/build-docker-images.yml` runs on every push and auto-commits the backend/frontend image SHA tags into `docker-compose.yml`. The frontend step referenced the wrong step id, so `SHORT_HASH` was always empty and the sed blanked out the frontend image tag instead of setting it, e.g.:

```diff
-    image: 'ghcr.io/project-chip/csa-certification-tool-frontend:5be5818'
+    image: 'ghcr.io/project-chip/csa-certification-tool-frontend:'
```

This was observed live on an unrelated docs PR (#1101), where the workflow fired on push and committed this blank-tag change directly onto that branch.

## Changes

- `Ensure frontend sha is used in docker-compose` step now reads `steps.frontend_tag.outputs.tag` (matching the id of the `Store frontend tag` step) instead of the nonexistent `steps.frontend.outputs.tag`.

## Testing

- N/A (workflow-only fix). Pushing this branch will itself trigger `build-docker-images.yml`; verify in the Actions run for this branch that the frontend tag step now populates `docker-compose.yml` with a real short SHA instead of blanking it.