### PR TITLE
Add CNET test instructions to Matter TH User Guide

### DIFF
--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -2041,6 +2041,7 @@ WARNING: Currently, WIFI_SSID with special characters or empty spaces is not sup
 * *$BLE_INTERFACE_ID*: Interface ID for BLE interface (e.g., 0 for default, which usually works)
 * *$THREAD_DATASET_HEX*: Thread operational dataset as a hex string (e.g., output of dataset active -x in OpenThread CLI on an existing end-device
 
+[[common-steps]]
 ===== Common Steps
 
 |===
@@ -2106,6 +2107,15 @@ Execute the below command in the docker for the BLE+Thread pairing:
 |`rm -f admin_storage.json && python3 python_testing/scripts/sdk/TC_RR_1_1.py --discriminator $DISCRIMINATOR --passcode $SETUP_PASSCODE --commissioning-method ble-thread --paa-trust-store-path /paa_roots --storage-path admin_storage.json --thread-dataset-hex $THREAD_DATASET_HEX --ble-interface-id $BLE_INTERFACE_ID`
 |===
 
+===== For CNET Tests
+
+CNET (Network Commissioning cluster) test cases manage Wi-Fi networks directly through the host's `wpa_supplicant` control interface, so the `chip-cert-bins` container needs an additional volume mapping for `/var/run/wpa_supplicant` on top of the <<common-steps,Common Steps>> command:
+
+|===
+|`docker run -v $PATH_TO_PAA_ROOTS:/paa_roots -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket -v /home/ubuntu/certification-tool/backend/test_collections/matter/sdk_tests/sdk_checkout/python_testing:/root/python_testing -v $(pwd):/launch_dir -v /var/run/wpa_supplicant:/var/run/wpa_supplicant --privileged --network host -it connectedhomeip/chip-cert-bins:<SDK SHA RECOMMENDED>`
+|===
+
+NOTE: Without this mapping, CNET test cases will fail to reach `wpa_supplicant` and cannot add, update, or remove Wi-Fi networks.
 
 ===== Post-Test Steps
 

--- a/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
+++ b/docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc
@@ -168,6 +168,7 @@ endif::[]
                                                                      * Documented the `--prompt-timeout` CLI flag for `run-tests`.
 | 71          | 03-Sep-2026  | [Apple]Romulo Quidute               | * Updated Section 7.1 to use the current standalone nRF Util executable instead of the deprecated pip-based nrfutil package, and to clarify RCP dongle flashing can be done from a separate Mac/PC.
 | 72          | 04-Sep-2026  | [Apple]Antonio Melo Jr.             | * Updated Container Logging Configuration section to document the `th_config.enable_container_logs` per-project override (issue #1091).
+| 73          | 10-Sep-2026  | [Google]Andrey Khodyrev             | * Added 'For CNET Tests' section with wpa_supplicant volume mapping instructions for the SDK docker container.
 |===
 
 <<<


### PR DESCRIPTION
## Summary

  Documents the additional `wpa_supplicant` volume mapping required when
  manually starting the `chip-cert-bins` SDK container to run CNET (Network
  Commissioning cluster) test cases.

  ## Background

  CNET test cases manage Wi-Fi networks on the DUT/TH directly through the
  host's `wpa_supplicant` control interface. The existing "SDK Python Tests →
  Run Tests Inside SDK Docker Container" instructions in the TH User Guide only
  document the base `docker run` command (D-Bus socket, PAA roots,
  python_testing tree, etc.) and per-pairing-method sections (NFC, on-network, 
  BLE+Wi-Fi, BLE+Thread) — none of which mount `/var/run/wpa_supplicant`.
  Testers running CNET tests had to figure out and add this mapping themselves.

  ## Changes

  - `docs/Matter_TH_User_Guide/Matter_TH_User_Guide.adoc`:
    - Added anchor `[[common-steps]]` above the existing `===== Common Steps`
  heading so it can be cross-referenced.
    - Added a new `===== For CNET Tests` subsection (after "For BLE+Thread
  Pairing") with the full `docker run` command including `-v
  /var/run/wpa_supplicant:/var/run/wpa_supplicant`, and a note explaining why
  the mapping is required.

  ## Related

  Companion code change: https://github.com/project-chip/certification-tool-backend/pull/368